### PR TITLE
input name attr and hidden type

### DIFF
--- a/src/components/Input.react.js
+++ b/src/components/Input.react.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 
 /**
- * A basic HTML input control for entering text, numbers, or passwords.
+ * A basic HTML input control for entering text, numbers, passwords, or hidden fields.
  *
  * Note that checkbox and radio types are supported through
  * the Checklist and RadioItems component. Dates, times, and file uploads
@@ -16,6 +16,7 @@ export default class Input extends Component {
             fireEvent,
             placeholder,
             style,
+            name,
             value,
             type,
             setProps
@@ -29,6 +30,7 @@ export default class Input extends Component {
                 value={value}
                 placeholder={placeholder}
                 style={style}
+                name={name}
                 onChange={e => {
                     if (setProps) setProps({value: e.target.value});
                     if (fireEvent) fireEvent({event: 'change'});
@@ -68,6 +70,11 @@ Input.propTypes = {
     style: PropTypes.object,
 
     /**
+     * The name of the input element
+     */
+    name: PropTypes.string,
+
+    /**
      * The class of the input element
      */
     className: PropTypes.string,
@@ -76,7 +83,7 @@ Input.propTypes = {
      * The type of control to render.
      */
     type: PropTypes.oneOf([
-        'text', 'number', 'password'
+        'text', 'number', 'password', 'hidden'
     ]),
 
     /**


### PR DESCRIPTION
hi there - any objection to adding a hidden type and name attribute to the input component?

i'm able to add the hidden type anyway as it doesn't seem to be validated but i'm unable to add the name attribute :(

use case:

```
dcc.Input(
    name='_csrf_token',
    type='hidden',
    value=app.server.jinja_env.globals['csrf_token'](),
)
```