### PR TITLE
[MRG] Add basic textarea component

### DIFF
--- a/dash_core_components/metadata.json
+++ b/dash_core_components/metadata.json
@@ -1294,5 +1294,84 @@
         "description": "inline style to be passed to the span wrapping each line if wrapLines is true. Can be either an object or a function that recieves current line number as argument and returns style object."
       }
     }
+  },
+  "src/components/Textarea.react.js": {
+    "description": "A basic HTML textarea for entering multiline text.",
+    "methods": [],
+    "props": {
+      "id": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": ""
+      },
+      "value": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "The value of the textarea"
+      },
+      "placeholder": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "A hint to the user of what can be entered in the control.\nNote: Do not use the placeholder attribute instead of a Label element,\ntheir purposes are different.\nThe Label attribute describes the role of the form element\n(i.e. it indicates what kind of information is expected),\nand the placeholder attribute is a hint about the format\nthat the value should take.\nThere are cases in which the placeholder attribute is\nnever displayed to the user, so the form must be understandable\nwithout it."
+      },
+      "style": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "The input's inline styles"
+      },
+      "className": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "The class of the input element"
+      },
+      "disabled": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "If disabled, then the input can not be edited"
+      },
+      "fireEvent": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "Dash-assigned callback that gets fired when the input changes."
+      },
+      "setProps": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "Dash-assigned callback that gets fired when the value changes."
+      },
+      "dashEvents": {
+        "type": {
+          "name": "enum",
+          "value": [
+            {
+              "value": "'blur'",
+              "computed": false
+            },
+            {
+              "value": "'change'",
+              "computed": false
+            }
+          ]
+        },
+        "required": false,
+        "description": ""
+      }
+    }
   }
 }

--- a/dash_core_components/metadata.json
+++ b/dash_core_components/metadata.json
@@ -1304,7 +1304,7 @@
           "name": "string"
         },
         "required": false,
-        "description": ""
+        "description": "The ID of this component, used to identify dash components\nin callbacks. The ID needs to be unique across all of the\ncomponents in an app."
       },
       "value": {
         "type": {
@@ -1313,40 +1313,173 @@
         "required": false,
         "description": "The value of the textarea"
       },
+      "autoFocus": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "The element should be automatically focused after the page loaded."
+      },
+      "cols": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Defines the number of columns in a textarea."
+      },
+      "disabled": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Indicates whether the user can interact with the element."
+      },
+      "form": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Indicates the form that is the owner of the element."
+      },
+      "maxLength": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Defines the maximum number of characters allowed in the element."
+      },
+      "minLength": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Defines the minimum number of characters allowed in the element."
+      },
+      "name": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Name of the element. For example used by the server to identify the fields in form submits."
+      },
       "placeholder": {
         "type": {
           "name": "string"
         },
         "required": false,
-        "description": "A hint to the user of what can be entered in the control.\nNote: Do not use the placeholder attribute instead of a Label element,\ntheir purposes are different.\nThe Label attribute describes the role of the form element\n(i.e. it indicates what kind of information is expected),\nand the placeholder attribute is a hint about the format\nthat the value should take.\nThere are cases in which the placeholder attribute is\nnever displayed to the user, so the form must be understandable\nwithout it."
+        "description": "Provides a hint to the user of what can be entered in the field."
       },
-      "style": {
+      "readOnly": {
         "type": {
-          "name": "object"
+          "name": "string"
         },
         "required": false,
-        "description": "The input's inline styles"
+        "description": "Indicates whether the element can be edited."
+      },
+      "required": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Indicates whether this element is required to fill out or not."
+      },
+      "rows": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Defines the number of rows in a text area."
+      },
+      "wrap": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Indicates whether the text should be wrapped."
+      },
+      "accessKey": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Defines a keyboard shortcut to activate or add focus to the element."
       },
       "className": {
         "type": {
           "name": "string"
         },
         "required": false,
-        "description": "The class of the input element"
+        "description": "Often used with CSS to style elements with common properties."
       },
-      "disabled": {
+      "contentEditable": {
         "type": {
-          "name": "bool"
+          "name": "string"
         },
         "required": false,
-        "description": "If disabled, then the input can not be edited"
+        "description": "Indicates whether the element's content is editable."
       },
-      "fireEvent": {
+      "contextMenu": {
         "type": {
-          "name": "func"
+          "name": "string"
         },
         "required": false,
-        "description": "Dash-assigned callback that gets fired when the input changes."
+        "description": "Defines the ID of a <menu> element which will serve as the element's context menu."
+      },
+      "dir": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)"
+      },
+      "draggable": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Defines whether the element can be dragged."
+      },
+      "hidden": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Prevents rendering of given element, while keeping child elements, e.g. script elements, active."
+      },
+      "lang": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Defines the language used in the element."
+      },
+      "spellCheck": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Indicates whether spell checking is allowed for the element."
+      },
+      "style": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "Defines CSS styles which will override styles previously set."
+      },
+      "tabIndex": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Overrides the browser's default tab order and follows the one specified instead."
+      },
+      "title": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Text to be displayed in a tooltip when hovering over the element."
       },
       "setProps": {
         "type": {
@@ -1355,10 +1488,21 @@
         "required": false,
         "description": "Dash-assigned callback that gets fired when the value changes."
       },
+      "fireEvent": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "A callback for firing events to dash."
+      },
       "dashEvents": {
         "type": {
           "name": "enum",
           "value": [
+            {
+              "value": "'click'",
+              "computed": false
+            },
             {
               "value": "'blur'",
               "computed": false

--- a/src/components/Textarea.react.js
+++ b/src/components/Textarea.react.js
@@ -16,22 +16,14 @@ export default class Textarea extends Component {
 
     render() {
         const {
-            className,
-            id,
             fireEvent,
-            placeholder,
-            style,
             setProps
         } = this.props;
         const {value} = this.state;
 
         return (
             <textarea
-                className={className}
-                id={id}
                 value={value}
-                placeholder={placeholder}
-                style={style}
                 onChange={e => {
                     this.setState({value: e.target.value});
                     if (setProps) setProps({value: e.target.value});
@@ -40,56 +32,159 @@ export default class Textarea extends Component {
                 onBlur={() => {
                     if (fireEvent) fireEvent({event: 'blur'});
                 }}
+                onClick={() => {
+                    if (fireEvent) fireEvent({event: 'click'});
+                }}
+                {...this.props}
             />
         );
     }
 }
 
+
 Textarea.propTypes = {
-    id: PropTypes.string,
+    /**
+     * The ID of this component, used to identify dash components
+     * in callbacks. The ID needs to be unique across all of the
+     * components in an app.
+     */
+    'id': PropTypes.string,
+
     /**
      * The value of the textarea
      */
     value: PropTypes.string,
 
     /**
-     * A hint to the user of what can be entered in the control.
-     * Note: Do not use the placeholder attribute instead of a Label element,
-     * their purposes are different.
-     * The Label attribute describes the role of the form element
-     * (i.e. it indicates what kind of information is expected),
-     * and the placeholder attribute is a hint about the format
-     * that the value should take.
-     * There are cases in which the placeholder attribute is
-     * never displayed to the user, so the form must be understandable
-     * without it.
+     * The element should be automatically focused after the page loaded.
      */
-    placeholder: PropTypes.string,
+    'autoFocus': PropTypes.string,
 
     /**
-     * The input's inline styles
+     * Defines the number of columns in a textarea.
      */
-    style: PropTypes.object,
+    'cols': PropTypes.string,
 
     /**
-     * The class of the input element
+     * Indicates whether the user can interact with the element.
      */
-    className: PropTypes.string,
+    'disabled': PropTypes.string,
 
     /**
-     * If disabled, then the input can not be edited
+     * Indicates the form that is the owner of the element.
      */
-    disabled: PropTypes.bool,
+    'form': PropTypes.string,
 
     /**
-     * Dash-assigned callback that gets fired when the input changes.
+     * Defines the maximum number of characters allowed in the element.
      */
-    fireEvent: PropTypes.func,
+    'maxLength': PropTypes.string,
+
+    /**
+     * Defines the minimum number of characters allowed in the element.
+     */
+    'minLength': PropTypes.string,
+
+    /**
+     * Name of the element. For example used by the server to identify the fields in form submits.
+     */
+    'name': PropTypes.string,
+
+    /**
+     * Provides a hint to the user of what can be entered in the field.
+     */
+    'placeholder': PropTypes.string,
+
+    /**
+     * Indicates whether the element can be edited.
+     */
+    'readOnly': PropTypes.string,
+
+    /**
+     * Indicates whether this element is required to fill out or not.
+     */
+    'required': PropTypes.string,
+
+    /**
+     * Defines the number of rows in a text area.
+     */
+    'rows': PropTypes.string,
+
+    /**
+     * Indicates whether the text should be wrapped.
+     */
+    'wrap': PropTypes.string,
+
+    /**
+     * Defines a keyboard shortcut to activate or add focus to the element.
+     */
+    'accessKey': PropTypes.string,
+
+    /**
+     * Often used with CSS to style elements with common properties.
+     */
+    'className': PropTypes.string,
+
+    /**
+     * Indicates whether the element's content is editable.
+     */
+    'contentEditable': PropTypes.string,
+
+    /**
+     * Defines the ID of a <menu> element which will serve as the element's context menu.
+     */
+    'contextMenu': PropTypes.string,
+
+    /**
+     * Defines the text direction. Allowed values are ltr (Left-To-Right) or rtl (Right-To-Left)
+     */
+    'dir': PropTypes.string,
+
+    /**
+     * Defines whether the element can be dragged.
+     */
+    'draggable': PropTypes.string,
+
+    /**
+     * Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+     */
+    'hidden': PropTypes.string,
+
+    /**
+     * Defines the language used in the element.
+     */
+    'lang': PropTypes.string,
+
+    /**
+     * Indicates whether spell checking is allowed for the element.
+     */
+    'spellCheck': PropTypes.string,
+
+    /**
+     * Defines CSS styles which will override styles previously set.
+     */
+    'style': PropTypes.object,
+
+    /**
+     * Overrides the browser's default tab order and follows the one specified instead.
+     */
+    'tabIndex': PropTypes.string,
+
+    /**
+     * Text to be displayed in a tooltip when hovering over the element.
+     */
+    'title': PropTypes.string,
 
     /**
      * Dash-assigned callback that gets fired when the value changes.
      */
     setProps: PropTypes.func,
 
-    dashEvents: PropTypes.oneOf(['blur', 'change'])
+    /**
+     * A callback for firing events to dash.
+     */
+    'fireEvent': PropTypes.func,
+
+    'dashEvents': PropTypes.oneOf(['click', 'blur', 'change'])
+
 };

--- a/src/components/Textarea.react.js
+++ b/src/components/Textarea.react.js
@@ -1,0 +1,95 @@
+import React, {Component, PropTypes} from 'react';
+
+/**
+ * A basic HTML textarea for entering multiline text.
+ *
+ */
+export default class Textarea extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {value: props.value};
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.setState({value: nextProps.value});
+    }
+
+    render() {
+        const {
+            className,
+            id,
+            fireEvent,
+            placeholder,
+            style,
+            setProps
+        } = this.props;
+        const {value} = this.state;
+
+        return (
+            <textarea
+                className={className}
+                id={id}
+                value={value}
+                placeholder={placeholder}
+                style={style}
+                onChange={e => {
+                    this.setState({value: e.target.value});
+                    if (setProps) setProps({value: e.target.value});
+                    if (fireEvent) fireEvent({event: 'change'});
+                }}
+                onBlur={() => {
+                    if (fireEvent) fireEvent({event: 'blur'});
+                }}
+            />
+        );
+    }
+}
+
+Textarea.propTypes = {
+    id: PropTypes.string,
+    /**
+     * The value of the textarea
+     */
+    value: PropTypes.string,
+
+    /**
+     * A hint to the user of what can be entered in the control.
+     * Note: Do not use the placeholder attribute instead of a Label element,
+     * their purposes are different.
+     * The Label attribute describes the role of the form element
+     * (i.e. it indicates what kind of information is expected),
+     * and the placeholder attribute is a hint about the format
+     * that the value should take.
+     * There are cases in which the placeholder attribute is
+     * never displayed to the user, so the form must be understandable
+     * without it.
+     */
+    placeholder: PropTypes.string,
+
+    /**
+     * The input's inline styles
+     */
+    style: PropTypes.object,
+
+    /**
+     * The class of the input element
+     */
+    className: PropTypes.string,
+
+    /**
+     * If disabled, then the input can not be edited
+     */
+    disabled: PropTypes.bool,
+
+    /**
+     * Dash-assigned callback that gets fired when the input changes.
+     */
+    fireEvent: PropTypes.func,
+
+    /**
+     * Dash-assigned callback that gets fired when the value changes.
+     */
+    setProps: PropTypes.func,
+
+    dashEvents: PropTypes.oneOf(['blur', 'change'])
+};

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import Interval from './components/Interval.react';
 import Markdown from './components/Markdown.react';
 import Location from './components/Location.react';
 import Link from './components/Link.react';
+import Textarea from './components/Textarea.react';
 
 export {
     Checklist,
@@ -24,5 +25,6 @@ export {
     Interval,
     Markdown,
     Location,
-    Link
+    Link,
+    Textarea
 };


### PR DESCRIPTION
This adds a basic `<textarea>` component. Mostly a straight copy of `<input>`.

Seems to work but the dev instructions in the README don't quite work for me (in terms of what I need to rerun when etc). However a small dash app that uses a textarea instead of an input works.

Should we add some more of the `wrap`, `rows`, `cols` properties? Anything else?