### PR TITLE
Allow children in Checklist options

### DIFF
--- a/demo/Demo.react.js
+++ b/demo/Demo.react.js
@@ -299,6 +299,48 @@ class Controller extends Component {
 ReactDOM.render(<Controller/>, mountNode);`
 
 
+const ChecklistContainerExample = `
+const applesDescription = (<div style={{marginLeft: '20px', marginBottom: '20px'}}>
+                                <p><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Apples.jpg/97px-Apples.jpg" alt="Apples.jpg" /></p>
+                                <p>This option selects the best and most fancy apples in the world</p>
+                            </div>);
+
+const orangesDescription = (<p style={{marginLeft: '15px'}}>There is no oranges available. Please come back in oranges season.</p>);
+
+const properties = {
+    id: 'my checklist',
+    labelStyle: {'display': 'block'},
+    disabled: false,
+    options: [
+        {'label': 'Melons', 'value': 'melons', 'disabled': false},
+        {'label': 'Apples', 'value': 'apples', 'children': [applesDescription]},
+        {'label': 'Oranges', 'value': 'oranges', 'disabled': true, 'children': [orangesDescription]}
+    ]
+};
+
+class Controller extends Component {
+    constructor() {
+        super();
+        this.state = {
+            values: ['melons', 'apples']
+        };
+    }
+
+    render() {
+        return (<Checklist
+            setProps={(props) => {
+                this.setState(props);
+            }}
+            fireEvent={event => console.warn(event)}
+            values={this.state.values}
+            {...properties}
+        />);
+    }
+}
+
+ReactDOM.render(<Controller/>, mountNode);`
+
+
 
 const examples = [
     {name: 'Upload', code: UploadExample},
@@ -308,6 +350,7 @@ const examples = [
     {name: 'SyntaxHighlighter', code: SyntaxHighlighterExample},
     {name: 'Radio', code: RadioExample},
     {name: 'Checklist', code: ChecklistExample},
+    {name: 'Checklist with containers options', code: ChecklistContainerExample},
     {name: 'Dropdown', code: DropdownExample},
     {name: 'Slider', code: SliderExample},
     {name: 'RangeSlider', code: RangeSliderExample},

--- a/demo/Demo.react.js
+++ b/demo/Demo.react.js
@@ -268,7 +268,6 @@ const ChecklistExample = `
 const properties = {
     id: 'my checklist',
     labelStyle: {'display': 'block'},
-    disabled: false,
     options: [
         {'label': 'Melons', 'value': 'melons', 'disabled': false},
         {'label': 'Apples', 'value': 'apples'},
@@ -308,13 +307,19 @@ const applesDescription = (<div style={{marginLeft: '20px', marginBottom: '20px'
 const orangesDescription = (<p style={{marginLeft: '15px'}}>There is no oranges available. Please come back in oranges season.</p>);
 
 const properties = {
-    id: 'my checklist',
+    id: 'my container checklist',
     labelStyle: {'display': 'block'},
-    disabled: false,
     options: [
         {'label': 'Melons', 'value': 'melons', 'disabled': false},
-        {'label': 'Apples', 'value': 'apples', 'children': [applesDescription]},
-        {'label': 'Oranges', 'value': 'oranges', 'disabled': true, 'children': [orangesDescription]}
+        {'label': 'Apples', 'value': 'apples',
+            'children': applesDescription,
+            'collapseChildrenButton': true,
+            'initiallyExpanded': false
+            },
+        {'label': 'Oranges', 'value': 'oranges', 'disabled': true,
+        'children': orangesDescription,
+        'collapseChildrenButton': true,
+        'initiallyExpanded': true}
     ]
 };
 

--- a/src/components/Checklist.react.js
+++ b/src/components/Checklist.react.js
@@ -59,6 +59,7 @@ export default class Checklist extends Component {
                             }}
                         />
                         {option.label}
+                        {option.children}
                     </label>
                 ))}
             </div>
@@ -88,7 +89,13 @@ Checklist.propTypes = {
         /**
          * If true, this checkbox is disabled and can't be clicked on.
          */
-        disabled: PropTypes.bool
+        disabled: PropTypes.bool,
+
+
+        /**
+         * Optinal wrapped components within this option
+         */
+        children: PropTypes.node
     }),
 
     /**

--- a/src/components/__tests__/Checklist.test.js
+++ b/src/components/__tests__/Checklist.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import CheckListComponent from '../Checklist.react';
+
+describe('Checklist component', () => {
+
+    it('renders', () => {
+        const component = shallow(<CheckListComponent id="my-checklist"/>);
+        expect(component).to.be.ok;
+    });
+
+    describe('options', () => {
+        it('renders passed-in options');
+    });
+});


### PR DESCRIPTION
I'm developing a webapp which needs to have checkboxes that contain another (Dash's) React 
component, so I've modified the Checklist component to allow to include options with children components, as well as a button to show/hide those children.

Here is a short "demo":
![anim](https://user-images.githubusercontent.com/2631430/32248954-9266fe06-be87-11e7-8333-25b0704a163c.gif)

This is a first approach, so take it as a prototype. We can work on it and improve it until it reaches a production-ready code and then we can squash all commits and merge with master.