### PR TITLE
Fixed some warnings

### DIFF
--- a/demo/Demo.react.js
+++ b/demo/Demo.react.js
@@ -320,8 +320,8 @@ class Demo extends Component {
             <div style={{'fontFamily': 'Sans-Serif'}}>
                 <h1>Dash Core Component Suite Demo</h1>
 
-                {examples.map(example =>
-                    <div>
+                {examples.map((example, index) =>
+                    <div key={index}>
                         <div style={{'marginBottom': 150}}>
                             <h3>{example.name}</h3>
                             <Playground

--- a/src/components/Checklist.react.js
+++ b/src/components/Checklist.react.js
@@ -72,24 +72,26 @@ Checklist.propTypes = {
     /**
      * An array of options
      */
-    options: PropTypes.shape({
-        /**
-         * The checkbox's label
-         */
-        label: PropTypes.string,
+     options: PropTypes.arrayOf(
+         PropTypes.shape({
+            /**
+             * The checkbox's label
+             */
+            label: PropTypes.string,
 
-        /**
-         * The value of the checkbox. This value
-         * corresponds to the items specified in the
-         * `values` property.
-         */
-        value: PropTypes.string,
+            /**
+             * The value of the checkbox. This value
+             * corresponds to the items specified in the
+             * `values` property.
+             */
+            value: PropTypes.string,
 
-        /**
-         * If true, this checkbox is disabled and can't be clicked on.
-         */
-        disabled: PropTypes.bool
-    }),
+            /**
+             * If true, this checkbox is disabled and can't be clicked on.
+             */
+            disabled: PropTypes.bool
+        })
+    ),
 
     /**
      * The currently selected value

--- a/src/components/Dropdown.react.js
+++ b/src/components/Dropdown.react.js
@@ -103,24 +103,26 @@ Dropdown.propTypes = {
     /**
      * An array of options
      */
-    options: PropTypes.shape({
-        /**
-         * The checkbox's label
-         */
-        label: PropTypes.string,
+     options: PropTypes.arrayOf(
+         PropTypes.shape({
+            /**
+             * The checkbox's label
+             */
+            label: PropTypes.string,
 
-        /**
-         * The value of the checkbox. This value
-         * corresponds to the items specified in the
-         * `values` property.
-         */
-        value: PropTypes.string,
+            /**
+             * The value of the checkbox. This value
+             * corresponds to the items specified in the
+             * `values` property.
+             */
+            value: PropTypes.string,
 
-        /**
-         * If true, this checkbox is disabled and can't be clicked on.
-         */
-        disabled: PropTypes.bool
-    }),
+            /**
+             * If true, this checkbox is disabled and can't be clicked on.
+             */
+            disabled: PropTypes.bool
+        })
+    ),
 
     /**
      * The value of the input. If `multi` is false (the default)

--- a/src/components/Interval.react.js
+++ b/src/components/Interval.react.js
@@ -68,12 +68,12 @@ Interval.propTypes = {
     /**
      * Dash assigned callback
      */
-    fireEvent: PropTypes.function,
+    fireEvent: PropTypes.func,
 
     /**
      * Dash assigned callback
      */
-    setProps: PropTypes.function,
+    setProps: PropTypes.func,
 
     dashEvents: PropTypes.oneOf(['interval'])
 };

--- a/src/components/RadioItems.react.js
+++ b/src/components/RadioItems.react.js
@@ -39,7 +39,7 @@ export default class RadioItems extends Component {
         return (
             <div {...ids} className={className} style={style}>
                 {options.map(option => (
-                    <label style={labelStyle} className={labelClassName}>
+                    <label style={labelStyle} className={labelClassName} key={option.value}>
                         <input
                             checked={option.value === value}
                             className={inputClassName}
@@ -66,24 +66,26 @@ RadioItems.propTypes = {
     /**
      * An array of options
      */
-    options: PropTypes.shape({
-        /**
-         * The radio item's label
-         */
-        label: PropTypes.string,
+    options: PropTypes.arrayOf(
+        PropTypes.shape({
+            /**
+             * The radio item's label
+             */
+            label: PropTypes.string,
 
-        /**
-         * The value of the radio item. This value
-         * corresponds to the items specified in the
-         * `values` property.
-         */
-        value: PropTypes.string,
+            /**
+             * The value of the radio item. This value
+             * corresponds to the items specified in the
+             * `values` property.
+             */
+            value: PropTypes.string,
 
-        /**
-         * If true, this radio item is disabled and can't be clicked on.
-         */
-        disabled: PropTypes.bool
-    }),
+            /**
+             * If true, this radio item is disabled and can't be clicked on.
+             */
+            disabled: PropTypes.bool
+        })
+    ),
 
     /**
      * The currently selected value

--- a/src/components/SyntaxHighlighter.react.js
+++ b/src/components/SyntaxHighlighter.react.js
@@ -58,7 +58,7 @@ SyntaxHighlighter.propTypes = {
     /**
      * if showLineNumbers is enabled the line numbering will start from here.
      */
-    startingLineNumber: PropTypes.bool,
+    startingLineNumber: PropTypes.number,
     /**
      * the line numbers container default to appearing to the left with 10px of right padding. You can use this to override those styles.
      */

--- a/src/components/Upload.react.js
+++ b/src/components/Upload.react.js
@@ -68,7 +68,7 @@ export default class Upload extends Component {
 
                 accept={accept}
                 disabled={disabled}
-                disableClic={disable_click}
+                disableClick={disable_click}
                 maxSize={max_size === -1 ? Infinity : max_size}
                 minSize={min_size}
                 multiple={multiple}


### PR DESCRIPTION
Looking the browser console I got these warnings:
```
Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `RadioItems`. See https://fb.me/react-warning-keys for more information.
    in label (created by RadioItems)
    in RadioItems
Warning: Failed prop type: Invalid prop `options` of type `array` supplied to `Checklist`, expected `object`.
    in Checklist (created by Controller)
    in Controller
```
This fixes them.