### PR TITLE
Remove duplicate CSS white-space key. The white-space CSS property is…

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -63,8 +63,7 @@ class Tests(IntegrationTests):
 
         pre_style = {
             'whiteSpace': 'pre-wrap',
-            'wordBreak': 'break-all',
-            'whiteSpace': 'normal'
+            'wordBreak': 'break-all'
         }
 
         app.layout = html.Div([

--- a/test/utils.py
+++ b/test/utils.py
@@ -13,7 +13,6 @@ def invincible(func):
     return wrap
 
 
-
 class WaitForTimeout(Exception):
     """This should only be raised inside the `wait_for` function."""
     pass


### PR DESCRIPTION
… specified as a single keyword chosen from the list of values as shown here: https://developer.mozilla.org/en-US/docs/Web/CSS/white-space