### PR TITLE
Support Dash-Renderer 2.0 - *Breaking Changes*

### DIFF
--- a/dash_core_components/metadata.json
+++ b/dash_core_components/metadata.json
@@ -1911,6 +1911,13 @@
         },
         "required": false,
         "description": ""
+      },
+      "render": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "Dash-assigned callback for rendering"
       }
     }
   },

--- a/src/components/RadioItems.react.js
+++ b/src/components/RadioItems.react.js
@@ -28,7 +28,8 @@ export default class RadioItems extends Component {
             labelClassName,
             labelStyle,
             options,
-            setProps
+            setProps,
+            render
         } = this.props;
         const {value} = this.state;
 
@@ -52,7 +53,7 @@ export default class RadioItems extends Component {
                                 if (fireEvent) fireEvent({event: 'change'});
                             }}
                         />
-                        {option.label}
+                        {render(option.label)}
                     </label>
                 ))}
             </div>
@@ -134,7 +135,12 @@ RadioItems.propTypes = {
      */
     setProps: PropTypes.func,
 
-    dashEvents: PropTypes.oneOf(['change'])
+    dashEvents: PropTypes.oneOf(['change']),
+
+    /**
+     * Dash-assigned callback for rendering
+     */
+    render: PropTypes.func
 };
 
 RadioItems.defaultProps = {


### PR DESCRIPTION
This PR updates the components to support the features introduced in https://github.com/plotly/dash-renderer/pull/32.

Namely, it will enable various properties across various components to accept arbitrary dash components as values. 

For example, the `label` property in `dcc.RadioItems` will be able to take a arbitrary Dash component instead of just a string.

i.e., instead of this:
```python
dcc.RadioItems(
    options=[
        {‘label’: ‘Item 1’, ‘value’: 1}, 
        {‘label’: ‘Item 2’, ‘value’: 1}
    ]
)
```

the developer could do this:
```python
dcc.RadioItems(
    options=[
        {‘label’: html.Div(‘Item 1’, style={‘color’: ‘cyan’}), ‘value’: 1}, 
        {‘label’: ‘Item 2’, ‘value’: 1}
    ]
)
```

This would require a dependency upgrade of `dash-renderer` to a 2.0 series, which would cause other component libraries that are not compatible with that version to break. There should be no breaking changes within this library.

This PR is a work-in-progress.