### PR TITLE
Remove listeners before reapplying them

### DIFF
--- a/src/components/Graph.react.js
+++ b/src/components/Graph.react.js
@@ -88,6 +88,7 @@ export default class PlotlyGraph extends Component {
         const {id, fireEvent, setProps, clear_on_unhover} = props;
 
         const gd = document.getElementById(id);
+        gd.removeAllListeners();
 
         gd.on('plotly_click', (eventData) => {
             const clickData = filterEventData(gd, eventData, 'click');


### PR DESCRIPTION
`newPlot` used to clear the event listeners before plotting, `react` no
longer does that. Just to be safe, we’ll always destroy before
attaching.

fixes https://github.com/plotly/dash-core-components/issues/171