### PR TITLE
add check that dash was correctly imported and exit with helpful message if failed

### DIFF
--- a/dash_core_components/__init__.py
+++ b/dash_core_components/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function as _
 
 import os as _os
 import sys as _sys

--- a/dash_core_components/__init__.py
+++ b/dash_core_components/__init__.py
@@ -1,7 +1,16 @@
+from __future__ import print_function
+
 import os as _os
 import sys as _sys
+
 import dash as _dash
+
 from .version import __version__
+
+if not hasattr(_dash, 'development'):
+    print("Dash was not successfully imported. Make sure you don't have a file "
+          "named \n'dash.py' in your current directory.", file=_sys.stderr)
+    _sys.exit(1)
 
 _current_path = _os.path.dirname(_os.path.abspath(__file__))
 

--- a/test/test_dash_import.py
+++ b/test/test_dash_import.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+
+
+class TestDashImport(unittest.TestCase):
+    def setUp(self):
+        with open('dash.py', 'w') as f:
+            pass        
+        
+    def tearDown(self):
+        try:
+            os.remove('dash.py')
+            os.remove('dash.pyc')
+        except OSError:
+            pass
+        
+    def test_dash_import(self):
+        """Test that program exits if the wrong dash module was imported"""
+        
+        with self.assertRaises(SystemExit) as cm:
+            import dash_html_components
+
+        self.assertEqual(cm.exception.code, 1)

--- a/test/test_dash_import.py
+++ b/test/test_dash_import.py
@@ -18,6 +18,6 @@ class TestDashImport(unittest.TestCase):
         """Test that program exits if the wrong dash module was imported"""
         
         with self.assertRaises(SystemExit) as cm:
-            import dash_html_components
+            import dash_core_components
 
         self.assertEqual(cm.exception.code, 1)

--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,5 @@ basepython={env:TOX_PYTHON_27}
 commands =
     python --version
     python -m unittest test.test_integration
+    python -m unittest test.test_dash_import
+    


### PR DESCRIPTION
A common gotcha that people new to Dash encounter is naming their script 'dash.py' which then shadows the Dash package itself, causing unhappy times. This adds an explicit check that the `dash.development` attribute exists, which if it doesn't, it's likely this situation has happened, so a more helpful error message is printed to standard error, and the script exits. 

This catches at least some of the times that this error occurs. If we also change the import order for example code from the Dash User guide to make `from dash.dependencies import Input, State, Output` come after after the import of `dash_core_components` this will then catch a lot more. 