### PR TITLE
rename dashFireEvent to fireEvent

### DIFF
--- a/dash_core_components/metadata.json
+++ b/dash_core_components/metadata.json
@@ -1253,7 +1253,7 @@
         "required": false,
         "description": "Function that updates the state tree."
       },
-      "dashFireEvent": {
+      "fireEvent": {
         "type": {
           "name": "func"
         },

--- a/src/components/Graph.react.js
+++ b/src/components/Graph.react.js
@@ -462,7 +462,7 @@ PlotlyGraph.propTypes = {
     /**
      * Function that fires events
      */
-    dashFireEvent: PropTypes.func
+    fireEvent: PropTypes.func
 }
 
 PlotlyGraph.defaultProps = {


### PR DESCRIPTION
Based on this code, it looks like the `dashFireEvent` props should be named `fireEvent`

https://github.com/plotly/dash-core-components/blob/9cafeee28f2d1b02bbb55a78c8e25030695c7793/src/components/Graph.react.js#L109-L146

Although, I vaguely recall @chriddyp mentioning at some point that [events](https://github.com/plotly/dash/blob/3dfa941fbba79efafc397360520f5a8e964236f6/dash/dependencies.py#L22-L26) may be deprecated at some point...are you still thinking that will be the case?