### PR TITLE
Table of contents component

### DIFF
--- a/src/components/TableOfContent.react.js
+++ b/src/components/TableOfContent.react.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const promiseWrap = (func, options={rejectNull: false}) => new Promise((resolve, reject) => {
+    const { rejectNull } = options;
+    let result;
+    try {
+        result = func();
+    } catch(e) {
+        reject(e);
+    }
+    if (rejectNull && !result) {reject('Expected promise result is null');}
+    else {resolve(result);}
+});
+
+const selectElement = (selector) => promiseWrap(() => document.querySelector(selector));
+
+const buildToc = (contentSelector, options={headings: ['h1', 'h2', 'h3', 'h4', 'h5']}) => selectElement(contentSelector).then(element => {
+    const { headings } = options;
+    let currentNode;
+    // noinspection JSCheckFunctionSignatures
+    const nodeIterator = document.createNodeIterator(element, NodeFilter.SHOW_ELEMENT,
+        (node) => headings.map(h => node.nodeName.toLowerCase().match(h)).reduce((a, e) => a || e) ?
+            NodeFilter.FILTER_ACCEPT :
+            NodeFilter.FILTER_REJECT);
+    let lastNodeId = 0;
+    const children = [];
+    // eslint-disable-next-line no-cond-assign
+    while(currentNode = nodeIterator.nextNode()) {
+        const nodeId = 'toc-' + lastNodeId++;
+        const nodeRefId = nodeId + '-ref';
+        const currentLevel = headings.indexOf(currentNode.nodeName.toLowerCase());
+        const nodeClass = 'toc-level-'+currentLevel;
+        const nodeContent = currentNode.textContent;
+        const idAttr = document.createAttribute('id');
+        idAttr.value = nodeRefId;
+        currentNode.attributes.setNamedItem(idAttr);
+        children.push(<li><a href={`#${nodeRefId}`} className={nodeClass}>{nodeContent}</a></li>);
+    }
+    return children;
+});
+
+
+export default class TableOfContent extends React.Component {
+    constructor(){
+        super();
+        this.state = {
+            children: null
+        };
+        this._observer = null;
+        this.buildToc = this.buildToc.bind(this);
+    }
+
+    buildToc() {
+        buildToc(this.props.content_selector)
+            .then(children => this.setState({children}));
+    }
+
+    componentDidMount() {
+        const { content_selector } = this.props;
+        selectElement(content_selector).then(element => {
+            const mutant = new MutationObserver(this.buildToc);
+            mutant.observe(element, {childList: true});
+            this._observer = mutant;
+        });
+        this.buildToc();
+    }
+
+    componentWillUnmount() {
+        this._observer.disconnect();
+    }
+
+    render() {
+        const {children} = this.state;
+        return (
+            <ul>
+                {children}
+            </ul>
+        );
+    }
+};
+
+TableOfContent.defaultProps = {};
+
+TableOfContent.propTypes = {
+    id: PropTypes.string,
+    /**
+     * Selector to search for building the toc.
+     */
+    content_selector: PropTypes.string,
+};

--- a/src/components/TableOfContent.react.js
+++ b/src/components/TableOfContent.react.js
@@ -52,7 +52,8 @@ export default class TableOfContent extends React.Component {
     }
 
     buildToc() {
-        buildToc(this.props.content_selector)
+        const { content_selector, headings } = this.props;
+        buildToc(content_selector, {headings})
             .then(children => this.setState({children}));
     }
 
@@ -80,7 +81,9 @@ export default class TableOfContent extends React.Component {
     }
 };
 
-TableOfContent.defaultProps = {};
+TableOfContent.defaultProps = {
+    headings: ['h1', 'h2', 'h3', 'h4', 'h5']
+};
 
 TableOfContent.propTypes = {
     id: PropTypes.string,
@@ -88,4 +91,9 @@ TableOfContent.propTypes = {
      * Selector to search for building the toc.
      */
     content_selector: PropTypes.string,
+
+    /**
+     * Headings tag name to search.
+     */
+    headings: PropTypes.arrayOf(PropTypes.string)
 };

--- a/src/components/TableOfContents.react.js
+++ b/src/components/TableOfContents.react.js
@@ -41,7 +41,7 @@ const buildToc = (contentSelector, options={headings: ['h1', 'h2', 'h3', 'h4', '
         });
     }
     return children;
-});
+};
 
 /**
  * Build a table of contents list with links to the headers tag.
@@ -90,9 +90,11 @@ export default class TableOfContents extends React.Component {
     }
 
     render() {
-        const {table_of_contents} = this.state;
+        const { id, className } = this.props;
+        const { table_of_contents } = this.state;
+
         return (
-            <ul>
+            <ul id={id} className={className}>
                 {table_of_contents && table_of_contents.map(
                     ({content, refId, level}) => <li>
                         <a
@@ -113,6 +115,11 @@ TableOfContents.defaultProps = {
 
 TableOfContents.propTypes = {
     id: PropTypes.string,
+
+    /**
+     * className for the top ul component.
+     */
+    className: PropTypes.string,
     /**
      * Selector to search for building the toc.
      */

--- a/src/components/TableOfContents.react.js
+++ b/src/components/TableOfContents.react.js
@@ -41,7 +41,7 @@ const buildToc = (contentSelector, options={headings: ['h1', 'h2', 'h3', 'h4', '
 });
 
 
-export default class TableOfContent extends React.Component {
+export default class TableOfContents extends React.Component {
     constructor(){
         super();
         this.state = {
@@ -81,11 +81,11 @@ export default class TableOfContent extends React.Component {
     }
 };
 
-TableOfContent.defaultProps = {
+TableOfContents.defaultProps = {
     headings: ['h1', 'h2', 'h3', 'h4', 'h5']
 };
 
-TableOfContent.propTypes = {
+TableOfContents.propTypes = {
     id: PropTypes.string,
     /**
      * Selector to search for building the toc.

--- a/src/components/TableOfContents.react.js
+++ b/src/components/TableOfContents.react.js
@@ -1,22 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const buildToc = (contentSelector, options={headings: ['h1', 'h2', 'h3', 'h4', 'h5']}) => {
-    const { headings } = options;
+const buildToc = (
+    contentSelector,
+    options = {headings: ['h1', 'h2', 'h3', 'h4', 'h5']}
+) => {
+    const {headings} = options;
     let currentNode;
     // noinspection JSCheckFunctionSignatures
     const nodeIterator = document.createNodeIterator(
-        document.querySelector(contentSelector), NodeFilter.SHOW_ELEMENT,
-        (node) => headings.map(h => node.nodeName.toLowerCase().match(h)).reduce((a, e) => a || e) ?
-            NodeFilter.FILTER_ACCEPT :
-            NodeFilter.FILTER_REJECT);
+        document.querySelector(contentSelector),
+        NodeFilter.SHOW_ELEMENT,
+        node =>
+            headings
+                .map(h => node.nodeName.toLowerCase().match(h))
+                .reduce((a, e) => a || e)
+                ? NodeFilter.FILTER_ACCEPT
+                : NodeFilter.FILTER_REJECT
+    );
     let lastNodeId = 0;
     const children = [];
     // eslint-disable-next-line no-cond-assign
-    while(currentNode = nodeIterator.nextNode()) {
+    while ((currentNode = nodeIterator.nextNode())) {
         const nodeId = 'toc-' + lastNodeId++;
         const nodeRefId = nodeId + '-ref';
-        const currentLevel = headings.indexOf(currentNode.nodeName.toLowerCase());
+        const currentLevel = headings.indexOf(
+            currentNode.nodeName.toLowerCase()
+        );
         const nodeContent = currentNode.textContent;
         const idAttr = document.createAttribute('id');
         idAttr.value = nodeRefId;
@@ -34,27 +44,27 @@ const buildToc = (contentSelector, options={headings: ['h1', 'h2', 'h3', 'h4', '
  * Build a table of contents list with links to the headers tag.
  */
 export default class TableOfContents extends React.Component {
-    constructor(props){
+    constructor(props) {
         super(props);
         this.state = {
-            table_of_contents: props.table_of_contents
+            table_of_contents: props.table_of_contents,
         };
         this._observer = null;
         this.buildToc = this.buildToc.bind(this);
     }
 
     buildToc() {
-        const { content_selector, headings, setProps } = this.props;
+        const {content_selector, headings, setProps} = this.props;
         const table_of_contents = buildToc(content_selector, {headings});
 
         this.setState({table_of_contents});
         if (setProps) {
-            setProps({table_of_contents})
+            setProps({table_of_contents});
         }
     }
 
     componentDidMount() {
-        const { content_selector } = this.props;
+        const {content_selector} = this.props;
         if (content_selector) {
             const content = document.querySelector(content_selector);
             this._observer = new MutationObserver(this.buildToc);
@@ -70,31 +80,38 @@ export default class TableOfContents extends React.Component {
     }
 
     componentWillReceiveProps(props) {
-        this.setState({table_of_contents: props.table_of_contents});
+        // The renderer also re-render the inputs after a callback.
+        // Check if falsy to not lose the toc.
+        // Means you can't mix callback controlled and state controlled easily.
+        if (props.table_of_contents) {
+            this.setState({table_of_contents: props.table_of_contents});
+        }
     }
 
     render() {
-        const { id, className } = this.props;
-        const { table_of_contents } = this.state;
+        const {id, className} = this.props;
+        const {table_of_contents} = this.state;
 
         return (
             <ul id={id} className={className}>
-                {table_of_contents && table_of_contents.map(
-                    ({content, refId, level}) => <li>
-                        <a
-                            href={`#${refId}`}
-                            className={`toc-level-${level}`}>
-                            {content}
-                        </a>
-                    </li>
-                )}
+                {table_of_contents &&
+                    table_of_contents.map(({content, refId, level}) => (
+                        <li>
+                            <a
+                                href={`#${refId}`}
+                                className={`toc-level-${level}`}
+                            >
+                                {content}
+                            </a>
+                        </li>
+                    ))}
             </ul>
         );
     }
-};
+}
 
 TableOfContents.defaultProps = {
-    headings: ['h1', 'h2', 'h3', 'h4', 'h5']
+    headings: ['h1', 'h2', 'h3', 'h4', 'h5'],
 };
 
 TableOfContents.propTypes = {
@@ -117,20 +134,22 @@ TableOfContents.propTypes = {
     /**
      * The table of content in object form.
      */
-    table_of_contents: PropTypes.arrayOf(PropTypes.shape({
-        /**
-         * The content of the heading.
-         */
-        content: PropTypes.string,
-        /**
-         * The level of the heading.
-         */
-        level: PropTypes.number,
-        /**
-         * The id to reference on the page. (scroll to)
-         */
-        refId: PropTypes.string,
-    })),
+    table_of_contents: PropTypes.arrayOf(
+        PropTypes.shape({
+            /**
+             * The content of the heading.
+             */
+            content: PropTypes.string,
+            /**
+             * The level of the heading.
+             */
+            level: PropTypes.number,
+            /**
+             * The id to reference on the page. (scroll to)
+             */
+            refId: PropTypes.string,
+        })
+    ),
 
-    setProps: PropTypes.any
+    setProps: PropTypes.any,
 };

--- a/src/components/TableOfContents.react.js
+++ b/src/components/TableOfContents.react.js
@@ -40,7 +40,9 @@ const buildToc = (contentSelector, options={headings: ['h1', 'h2', 'h3', 'h4', '
     return children;
 });
 
-
+/**
+ * Build a table of contents list with links to the headers tag.
+ */
 export default class TableOfContents extends React.Component {
     constructor(){
         super();
@@ -95,5 +97,7 @@ TableOfContents.propTypes = {
     /**
      * Headings tag name to search.
      */
-    headings: PropTypes.arrayOf(PropTypes.string)
+    headings: PropTypes.arrayOf(PropTypes.string),
+
+    setProps: PropTypes.any
 };

--- a/src/components/TableOfContents.react.js
+++ b/src/components/TableOfContents.react.js
@@ -30,12 +30,15 @@ const buildToc = (contentSelector, options={headings: ['h1', 'h2', 'h3', 'h4', '
         const nodeId = 'toc-' + lastNodeId++;
         const nodeRefId = nodeId + '-ref';
         const currentLevel = headings.indexOf(currentNode.nodeName.toLowerCase());
-        const nodeClass = 'toc-level-'+currentLevel;
         const nodeContent = currentNode.textContent;
         const idAttr = document.createAttribute('id');
         idAttr.value = nodeRefId;
         currentNode.attributes.setNamedItem(idAttr);
-        children.push(<li><a href={`#${nodeRefId}`} className={nodeClass}>{nodeContent}</a></li>);
+        children.push({
+            content: nodeContent,
+            level: currentLevel,
+            refId: nodeRefId,
+        });
     }
     return children;
 });
@@ -47,16 +50,21 @@ export default class TableOfContents extends React.Component {
     constructor(){
         super();
         this.state = {
-            children: null
+            table_of_contents: null
         };
         this._observer = null;
         this.buildToc = this.buildToc.bind(this);
     }
 
     buildToc() {
-        const { content_selector, headings } = this.props;
+        const { content_selector, headings, setProps } = this.props;
         buildToc(content_selector, {headings})
-            .then(children => this.setState({children}));
+            .then(table_of_contents =>{
+                this.setState({table_of_contents});
+                if (setProps) {
+                    setProps({table_of_contents})
+                }
+            });
     }
 
     componentDidMount() {
@@ -74,10 +82,18 @@ export default class TableOfContents extends React.Component {
     }
 
     render() {
-        const {children} = this.state;
+        const {table_of_contents} = this.state;
         return (
             <ul>
-                {children}
+                {table_of_contents && table_of_contents.map(
+                    ({content, refId, level}) => <li>
+                        <a
+                            href={`#${refId}`}
+                            className={`toc-level-${level}`}>
+                            {content}
+                        </a>
+                    </li>
+                )}
             </ul>
         );
     }
@@ -98,6 +114,8 @@ TableOfContents.propTypes = {
      * Headings tag name to search.
      */
     headings: PropTypes.arrayOf(PropTypes.string),
+
+    table_of_contents: PropTypes.array,
 
     setProps: PropTypes.any
 };

--- a/src/components/TableOfContents.react.js
+++ b/src/components/TableOfContents.react.js
@@ -47,10 +47,10 @@ const buildToc = (contentSelector, options={headings: ['h1', 'h2', 'h3', 'h4', '
  * Build a table of contents list with links to the headers tag.
  */
 export default class TableOfContents extends React.Component {
-    constructor(){
-        super();
+    constructor(props){
+        super(props);
         this.state = {
-            table_of_contents: null
+            table_of_contents: props.table_of_contents
         };
         this._observer = null;
         this.buildToc = this.buildToc.bind(this);
@@ -69,16 +69,24 @@ export default class TableOfContents extends React.Component {
 
     componentDidMount() {
         const { content_selector } = this.props;
-        selectElement(content_selector).then(element => {
-            const mutant = new MutationObserver(this.buildToc);
-            mutant.observe(element, {childList: true});
-            this._observer = mutant;
-        });
-        this.buildToc();
+        if (content_selector) {
+            selectElement(content_selector).then(element => {
+                const mutant = new MutationObserver(this.buildToc);
+                mutant.observe(element, {childList: true});
+                this._observer = mutant;
+            });
+            this.buildToc();
+        }
     }
 
     componentWillUnmount() {
-        this._observer.disconnect();
+        if (this._observer) {
+            this._observer.disconnect();
+        }
+    }
+
+    componentWillReceiveProps(props) {
+        this.setState({table_of_contents: props.table_of_contents});
     }
 
     render() {
@@ -115,7 +123,23 @@ TableOfContents.propTypes = {
      */
     headings: PropTypes.arrayOf(PropTypes.string),
 
-    table_of_contents: PropTypes.array,
+    /**
+     * The table of content in object form.
+     */
+    table_of_contents: PropTypes.arrayOf(PropTypes.shape({
+        /**
+         * The content of the heading.
+         */
+        content: PropTypes.string,
+        /**
+         * The level of the heading.
+         */
+        level: PropTypes.number,
+        /**
+         * The id to reference on the page. (scroll to)
+         */
+        refId: PropTypes.string,
+    })),
 
     setProps: PropTypes.any
 };

--- a/src/components/TableOfContents.react.js
+++ b/src/components/TableOfContents.react.js
@@ -26,7 +26,7 @@ const buildToc = (
                 ? NodeFilter.FILTER_ACCEPT
                 : NodeFilter.FILTER_REJECT
     );
-    let lastNodeId = 1;
+    let lastNodeId = 0;
     const children = [];
     // eslint-disable-next-line no-cond-assign
     while ((currentNode = nodeIterator.nextNode())) {
@@ -35,12 +35,14 @@ const buildToc = (
         const currentLevel = headings.indexOf(
             currentNode.nodeName.toLowerCase()
         );
-        const nodeContent = currentNode.textContent;
+
+        // Add an id to refer to.
         const idAttr = document.createAttribute('id');
         idAttr.value = nodeRefId;
         currentNode.attributes.setNamedItem(idAttr);
+
         const node = {
-            content: nodeContent,
+            content: currentNode.textContent,
             level: currentLevel,
             refId: nodeRefId,
             children: [],
@@ -48,6 +50,11 @@ const buildToc = (
 
         if (currentLevel > 0) {
             const lastLevel = last(levels[currentLevel - 1]);
+            if (!lastLevel) {
+                throw new Error(
+                    `Invalid leveling, no parent: ${headings[currentLevel]}`
+                );
+            }
             lastLevel.children.push(node);
         } else {
             children.push(node);
@@ -64,7 +71,7 @@ const renderToc = toc => {
         const t = toc[i];
         let node;
         const a = (
-            <a href={t.refId} className={`toc-level-${t.level}`}>
+            <a href={`#${t.refId}`} className={`toc-level-${t.level}`}>
                 {t.content}
             </a>
         );
@@ -169,6 +176,8 @@ TableOfContents.propTypes = {
 
     /**
      * Headings tag name to search.
+     * The table of contents will be leveled according to the order of
+     * the headings prop.
      */
     headings: PropTypes.arrayOf(PropTypes.string),
 

--- a/src/components/TableOfContents.react.js
+++ b/src/components/TableOfContents.react.js
@@ -141,7 +141,7 @@ export default class TableOfContents extends React.Component {
     }
 
     render() {
-        const {id, className} = this.props;
+        const {id, className, style} = this.props;
         const {table_of_contents} = this.state;
 
         if (!table_of_contents) {
@@ -151,7 +151,7 @@ export default class TableOfContents extends React.Component {
         const toc = renderToc(table_of_contents);
 
         return (
-            <ul id={id} className={className}>
+            <ul id={id} className={className} style={style}>
                 {toc}
             </ul>
         );
@@ -200,6 +200,11 @@ TableOfContents.propTypes = {
             refId: PropTypes.string,
         })
     ),
+
+    /**
+     * Style of the parent <ul>
+     */
+    style: PropTypes.object,
 
     setProps: PropTypes.any,
 };

--- a/src/components/TableOfContents.react.js
+++ b/src/components/TableOfContents.react.js
@@ -109,9 +109,10 @@ export default class TableOfContents extends React.Component {
         const {content_selector, headings, setProps} = this.props;
         const table_of_contents = buildToc(content_selector, {headings});
 
-        this.setState({table_of_contents});
         if (setProps) {
             setProps({table_of_contents});
+        } else {
+            this.setState({table_of_contents});
         }
     }
 
@@ -135,7 +136,10 @@ export default class TableOfContents extends React.Component {
         // The renderer also re-render the inputs after a callback.
         // Check if falsy to not lose the toc.
         // Means you can't mix callback controlled and state controlled easily.
-        if (props.table_of_contents) {
+        if (
+            props.table_of_contents &&
+            props.table_of_contents !== this.props.table_of_contents
+        ) {
             this.setState({table_of_contents: props.table_of_contents});
         }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ import Upload from './components/Upload.react';
 import Tabs from './components/Tabs.react';
 import Tab from './components/Tab.react';
 import Store from './components/Store.react';
-import TableOfContent from './components/TableOfContent.react';
+import TableOfContents from './components/TableOfContents.react';
 
 export {
     Checklist,
@@ -43,7 +43,6 @@ export {
     DatePickerSingle,
     DatePickerRange,
     Upload,
-    TableOfContent
-    Upload,
+    TableOfContents,
     Store,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ import Upload from './components/Upload.react';
 import Tabs from './components/Tabs.react';
 import Tab from './components/Tab.react';
 import Store from './components/Store.react';
+import TableOfContent from './components/TableOfContent.react';
 
 export {
     Checklist,
@@ -41,6 +42,8 @@ export {
     Textarea,
     DatePickerSingle,
     DatePickerRange,
+    Upload,
+    TableOfContent
     Upload,
     Store,
 };

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1304,3 +1304,45 @@ class Tests(IntegrationTests):
         list_btn.click()
         time.sleep(3)
         self.wait_for_text_to_equal('#output', json.dumps(nested_list))
+
+    def test_table_of_contents(self):
+        app = dash.Dash(__name__)
+
+        app.layout = html.Div([
+            dcc.TableOfContents(content_selector='#content', id='toc'),
+            html.Div(dcc.Markdown(dedent('''
+                # level one
+                
+                content
+                
+                ## level two
+                
+                content
+                
+                ### level three
+                
+                content
+                
+                #### level four
+                
+                content
+                
+                ##### level five
+                
+                content
+                
+            ''')), id='content'),
+            html.Div(id='output')
+        ])
+
+        @app.callback(Output('output', 'children'),
+                      [Input('toc', 'table_of_contents')])
+        def on_toc(toc):
+            if toc is None:
+                raise PreventUpdate
+            return json.dumps(toc)
+
+        self.startServer(app)
+
+        time.sleep(2)
+        self.snapshot('table-of-contents')

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1319,6 +1319,20 @@ class Tests(IntegrationTests):
                 
                 content
                 
+                ### level 2-1
+                
+                content
+                
+                ### level 2-2
+                
+                content
+                
+                ### level 2-3
+                
+                content
+                
+                ## level two-two
+                
                 ### level three
                 
                 content
@@ -1330,7 +1344,6 @@ class Tests(IntegrationTests):
                 ##### level five
                 
                 content
-                
             ''')), id='content'),
             html.Div(id='output')
         ])
@@ -1346,3 +1359,9 @@ class Tests(IntegrationTests):
 
         time.sleep(2)
         self.snapshot('table-of-contents')
+
+        toc_elem = self.driver.find_element_by_id('toc')
+
+        elems = toc_elem.find_elements_by_xpath('//a[contains(@href, "toc")]')
+
+        self.assertEqual(9, len(elems))


### PR DESCRIPTION
# Table of contents component

- Generate a table of content from the children of an element.
- Regenerate the table on content change using a MutationObserver.

@chriddyp asked for a table of contents in dash docs plotly/dash-docs#212. I remember I had made a gist with a table of content builder from markdown. I adapted the gist to a dash component.

https://gist.github.com/T4rk1n/9a44e6d0a2da88cd3b54d3328df29bb8

### Props:

- `id`
- `content_selector`, The css selector to build the table of contents from it's children.
- `headings` The tag names that will be included in the table of contents.

### Basic usage:

```python
import dash
import dash_core_components as dcc
import dash_html_components as html
from dash.dependencies import Output, Input
from dash.exceptions import PreventUpdate

app = dash.Dash(__name__)

app.scripts.config.serve_locally = True

md = dcc.Markdown('''
# level one

content

## level two

content

### level 2-1

content

### level 2-2

content

### level 2-3

content

## level two-two

### level three

content

#### level four

content

##### level five

content
'''
)

app.layout = html.Div([
    dcc.TableOfContents(content_selector='#content'),
    html.Div(id='content'),
    html.Button('fill', id='fill')
])


@app.callback(Output('content', 'children'), [Input('fill', 'n_clicks')])
def on_fill(n_clicks):
    if n_clicks is None:
        raise PreventUpdate

    return md
```

