### PR TITLE
Fixed wrong npm script name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm i
 2. Build the code:
 
 ```
-$ npm run build-all
+$ npm run build:all
 ```
 
 3. Install the library


### PR DESCRIPTION
it isn't build-all but build:all.
if you try to run build-all, npm actually throws an error telling you this:

```
npm ERR! missing script: build-all
npm ERR! 
npm ERR! Did you mean one of these?
npm ERR!     build:all
npm ERR!     build:py
npm ERR!     build:js
```

