### PR TITLE
Input only setState from props if setProps is defined.

### DIFF
--- a/src/components/Input.react.js
+++ b/src/components/Input.react.js
@@ -16,7 +16,13 @@ export default class Input extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        this.setState({value: nextProps.value});
+        if (this.props.setProps) {
+            // Only setState from props if the component is driven by props.
+            // If the component prop is not used in a callback,
+            // it will receive the same initial props every time
+            // the layout is updated.
+            this.setState({value: nextProps.value});
+        }
     }
 
     render() {


### PR DESCRIPTION
The component will receive the same initial props every time there is an update in the layout if they are not used in a callback and thus have no setProps. This add a check that only setState on the value if the component has setProps defined.