### PR TITLE
Fix store null values in lists

### DIFF
--- a/src/components/Store.react.js
+++ b/src/components/Store.react.js
@@ -4,7 +4,9 @@ import PropTypes from 'prop-types';
 
 function dataCheck(data, old) {
     // Assuming data and old are of the same type.
-    if (R.isNil(old) || R.isNil(data)) {
+    const oldNull = R.isNil(old);
+    const newNull = R.isNil(data);
+    if ((oldNull || newNull) && !(oldNull && newNull)) {
         return true;
     }
     const type = R.type(data);

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1558,3 +1558,25 @@ class Tests(IntegrationTests):
             # one for each hello world character  # noqa: W504
             len('hello world')
         )
+
+    def test_store_null_values(self):
+        # https://github.com/plotly/dash-core-components/issues/422
+        app = dash.Dash(__name__)
+        app.layout = html.Div([
+            html.Div(id='output'),
+            dcc.Store(id='store', data={'hello': [1.1, 1.1, None]})
+        ])
+
+        # Needs a callback with the store.
+        @app.callback(Output('output', 'children'),
+                      [Input('store', 'data')])
+        def hello(data):
+            if data is None:
+                raise PreventUpdate
+
+            return json.dumps(data)
+
+        self.startServer(app)
+
+        # Gets error loading dependencies.
+        self.wait_for_element_by_css_selector('#output')


### PR DESCRIPTION
Assert that both old and new data is not null when checking if the data needs update.

Part of fix for #422.

@rmarren1 please review.