### PR TITLE
Lock dash version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 dash_html_components
-dash>=0.31.0
+dash>=0.36.0
 percy
 selenium
 pandas

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(
     include_package_data=True,
     license='MIT',
     description='Dash UI core component suite',
-    install_requires=['dash']
+    install_requires=['dash>=0.36.0']
 )


### PR DESCRIPTION
Lock the dash version used in `install_requires` for the component classes.