### PR TITLE
:bug: add implicitly_wait

### DIFF
--- a/test/IntegrationTests.py
+++ b/test/IntegrationTests.py
@@ -105,6 +105,7 @@ class IntegrationTests(unittest.TestCase):
         time.sleep(2)
 
         # Visit the dash page
+        self.driver.implicitly_wait(2)
         self.driver.get('http://localhost:8050')
 
     def clear_log(self):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1531,13 +1531,14 @@ class Tests(IntegrationTests):
 
         self.startServer(app=app)
 
-        self.snapshot('2 graphs with different figures')
-
         # use this opportunity to test restyleData, since there are multiple
         # traces on this graph
         legendToggle = self.driver.find_element_by_css_selector('#example-graph .traces:first-child .legendtoggle')
         legendToggle.click()
         self.wait_for_text_to_equal('#restyle-data', '[{"visible": ["legendonly"]}, [0]]')
+
+        # move snapshot after click, so it's more stable with the wait
+        self.snapshot('2 graphs with different figures')
 
         # and test relayoutData while we're at it
         autoscale = self.driver.find_element_by_css_selector('#example-graph .ewdrag')


### PR DESCRIPTION
the added step  below was flakey because it has no implicitly_wait at web driver level, nor using the `wait_for` mechanism. this fix should solve this
`autoscale = self.driver.find_element_by_css_selector('#example-graph .ewdrag')`

we will run couple times to make sure it fixed
Fixes https://github.com/plotly/dash-core/issues/54
