### PR TITLE
Clean up components with new setProps logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,14 +28,10 @@ jobs:
                 command: |
                     git clone git@github.com:plotly/dash.git
                     git clone git@github.com:plotly/dash-html-components.git
+                    git clone git@github.com:plotly/dash-renderer.git
                     . venv/bin/activate
                     pip install -e ./dash --quiet
                     cd dash-html-components && npm install --ignore-scripts && npm run build && pip install -e . && cd ..
-            - run:
-                name: Install dash-renderer
-                command: |
-                    git clone git@github.com:plotly/dash-renderer.git
-                    . venv/bin/activate
                     cd dash-renderer && npm install --ignore-scripts && npm run build && npm run build:dev && pip install -e . && cd ..
             - run:
                   name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
                 command: |
                     git clone git@github.com:plotly/dash-renderer.git
                     . venv/bin/activate
-                    cd dash-renderer && npm install --ignore-scripts && npm run build && pip install -e . && cd ..
+                    cd dash-renderer && npm install --ignore-scripts && npm run build && npm run build:dev && pip install -e . && cd ..
             - run:
                   name: Build
                   command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,8 @@ jobs:
                 command: |
                     git clone git@github.com:plotly/dash.git
                     git clone git@github.com:plotly/dash-html-components.git
-                    git clone git@github.com:plotly/dash-table.git
                     . venv/bin/activate
                     pip install -e ./dash --quiet
-                    cd dash-core-components && npm install --ignore-scripts && npm run build && pip install -e . && cd ..
                     cd dash-html-components && npm install --ignore-scripts && npm run build && pip install -e . && cd ..
             - run:
                 name: Install dash-renderer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,14 +27,18 @@ jobs:
                 name: Install dependencies (dash)
                 command: |
                     git clone git@github.com:plotly/dash.git
-                    git clone git@github.com:plotly/dash-renderer.git
                     git clone git@github.com:plotly/dash-html-components.git
                     git clone git@github.com:plotly/dash-table.git
                     . venv/bin/activate
                     pip install -e ./dash --quiet
-                    cd dash-renderer && npm install --ignore-scripts && npm run build && pip install -e . && cd ..
                     cd dash-core-components && npm install --ignore-scripts && npm run build && pip install -e . && cd ..
                     cd dash-html-components && npm install --ignore-scripts && npm run build && pip install -e . && cd ..
+            - run:
+                name: Install dash-renderer
+                command: |
+                    git clone git@github.com:plotly/dash-renderer.git
+                    . venv/bin/activate
+                    cd dash-renderer && npm install --ignore-scripts && npm run build && pip install -e . && cd ..
             - run:
                   name: Build
                   command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     ```
     0 seconds: interval started with `interval=5000`
     5 seconds: `n_intervals=1`
-    7 seconds: callback sets `disabled=True`
-    10 seconds: interval continues to run, but doesn't fire an update
+    7 seconds: callback sets `disabled=True` - interval stops
     13 seconds: callback sets `disabled=False` - clock resets
-    17 seconds: interval fires an update: `n_intervals=2`
+    18 seconds: interval fires an update: `n_intervals=2`
     ```
 
 ## [0.46.0] - 2019-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Breaking** - `n_blur_timestamp` & `n_submit_timestamp` in `Input` & `Textarea` is now a number instead of a date object/string. This matches the form of `n_clicks_timestamp` as used in `dash_html_components`. [#523](https://github.com/plotly/dash-core-components/pull/523/)
 - Fixed an issue with `ConfirmDialog` that could display multiple confirm popups instead of a single popup in certain contexts. [#523](https://github.com/plotly/dash-core-components/pull/523/)
 
+### Changed
+- `dcc.Interval` will reset its timer when re-enabled. Previously, if the `dcc.Interval` was disabled, it's "clock would keep running": when it was reenabled, it would fire at the next `interval` on the previous clock's schedule, rather than `interval` milliseconds later. For example, previously the schedule might look like this:
+    ```
+    0 seconds: interval started with `interval=5000`
+    5 seconds: `n_intervals=1`
+    7 seconds: callback sets `disabled=True`
+    10 seconds: interval continues to run, but doesn't fire an update
+    13 seconds: callback sets `disabled=False`
+    15 seconds: interval fires an update: `n_intervals=2`
+    ```
+
+    Now, it will look like this:
+    ```
+    0 seconds: interval started with `interval=5000`
+    5 seconds: `n_intervals=1`
+    7 seconds: callback sets `disabled=True`
+    10 seconds: interval continues to run, but doesn't fire an update
+    13 seconds: callback sets `disabled=False` - clock resets
+    17 seconds: interval fires an update: `n_intervals=2`
+    ```
 
 ## [0.46.0] - 2019-04-10
 ### Added

--- a/jest.config.js
+++ b/jest.config.js
@@ -134,7 +134,6 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: [
-    "**/test/**/*.js?(x)",
     "**/?(*.)+(spec|test).js?(x)"
   ],
 

--- a/src/components/Checklist.react.js
+++ b/src/components/Checklist.react.js
@@ -9,15 +9,6 @@ import React, {Component} from 'react';
  * Each checkbox is rendered as an input with a surrounding label.
  */
 export default class Checklist extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {values: props.values};
-    }
-
-    componentWillReceiveProps(newProps) {
-        this.setState({values: newProps.values});
-    }
-
     render() {
         const {
             className,
@@ -30,8 +21,8 @@ export default class Checklist extends Component {
             setProps,
             style,
             loading_state,
+            values,
         } = this.props;
-        const {values} = this.state;
 
         return (
             <div
@@ -61,10 +52,7 @@ export default class Checklist extends Component {
                                 } else {
                                     newValues = append(option.value, values);
                                 }
-                                this.setState({values: newValues});
-                                if (setProps) {
-                                    setProps({values: newValues});
-                                }
+                                setProps({values: newValues});
                             }}
                         />
                         {option.label}

--- a/src/components/ConfirmDialog.react.js
+++ b/src/components/ConfirmDialog.react.js
@@ -8,10 +8,6 @@ import {Component} from 'react';
  * is performing an action that should require an extra step of verification.
  */
 export default class ConfirmDialog extends Component {
-    constructor(props) {
-        super(props);
-    }
-
     componentDidUpdate(prevProps) {
         this._update(!prevProps.displayed && this.props.displayed);
     }

--- a/src/components/ConfirmDialogProvider.react.js
+++ b/src/components/ConfirmDialogProvider.react.js
@@ -17,29 +17,14 @@ import ConfirmDialog from './ConfirmDialog.react';
  * ```
  */
 export default class ConfirmDialogProvider extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {displayed: props.displayed};
-    }
-
-    componentWillReceiveProps(props) {
-        this.setState({displayed: props.displayed});
-    }
-
     render() {
-        const {id, setProps, children, loading_state} = this.props;
-
-        const displayed = this.state.displayed;
+        const {displayed, id, setProps, children, loading_state} = this.props;
 
         // Will lose the previous onClick of the child
         const wrapClick = child => {
             const props = clone(child.props);
             props._dashprivate_layout.props.onClick = () => {
-                const update = {displayed: true};
-                this.setState(update);
-                if (setProps) {
-                    setProps(update);
-                }
+                setProps({displayed: true});
             };
 
             return React.cloneElement(child, props);

--- a/src/components/DatePickerRange.react.js
+++ b/src/components/DatePickerRange.react.js
@@ -41,7 +41,6 @@ export default class DatePickerRange extends Component {
 
     onDatesChange({startDate: start_date, endDate: end_date}) {
         const {setProps, updatemode} = this.props;
-        let payload;
 
         const oldMomentDates = this.props.id
             ? convertToMoment(this.props, ['start_date', 'end_date'])

--- a/src/components/DatePickerRange.react.js
+++ b/src/components/DatePickerRange.react.js
@@ -17,31 +17,18 @@ import convertToMoment from '../utils/convertToMoment';
  * which can be found here: https://github.com/airbnb/react-dates
  */
 export default class DatePickerRange extends Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.propsToState = this.propsToState.bind(this);
         this.onDatesChange = this.onDatesChange.bind(this);
         this.isOutsideRange = this.isOutsideRange.bind(this);
     }
 
     propsToState(newProps) {
-        /*
-         * state includes:
-         * - if no ID, user modifiable attributes (date)
-         * - moment converted attributes
-         */
-
-        const newState = convertToMoment(newProps, [
-            'initial_visible_month',
-            'max_date_allowed',
-            'min_date_allowed',
-        ]);
-
-        if (!newProps.id) {
-            newState.start_date = newProps.start_date;
-            newState.end_date = newProps.end_date;
-        }
-        this.setState(newState);
+        this.setState({
+            start_date: newProps.start_date,
+            end_date: newProps.end_date,
+        });
     }
 
     componentWillReceiveProps(newProps) {
@@ -62,7 +49,7 @@ export default class DatePickerRange extends Component {
 
         if (start_date && !start_date.isSame(oldMomentDates.start_date)) {
             if (updatemode === 'singledate') {
-                payload = {start_date: start_date.format('YYYY-MM-DD')};
+                setProps({start_date: start_date.format('YYYY-MM-DD')});
             } else {
                 this.setState({start_date: start_date.format('YYYY-MM-DD')});
             }
@@ -70,19 +57,13 @@ export default class DatePickerRange extends Component {
 
         if (end_date && !end_date.isSame(oldMomentDates.end_date)) {
             if (updatemode === 'singledate') {
-                payload = {end_date: end_date.format('YYYY-MM-DD')};
+                setProps({end_date: end_date.format('YYYY-MM-DD')});
             } else if (updatemode === 'bothdates') {
-                payload = {
+                setProps({
                     start_date: this.state.start_date,
                     end_date: end_date.format('YYYY-MM-DD'),
-                };
+                });
             }
-        }
-
-        if (this.props.id) {
-            setProps(payload);
-        } else {
-            this.setState(payload);
         }
     }
 
@@ -96,7 +77,7 @@ export default class DatePickerRange extends Component {
     }
 
     render() {
-        const {focusedInput, initial_visible_month} = this.state;
+        const {focusedInput} = this.state;
 
         const {
             calendar_orientation,
@@ -124,20 +105,14 @@ export default class DatePickerRange extends Component {
             end_date_id,
         } = this.props;
 
-        let start_date;
-        let end_date;
-        if (id) {
-            ({start_date, end_date} = convertToMoment(this.props, [
-                'start_date',
-                'end_date',
-            ]));
-        } else {
-            ({start_date, end_date} = convertToMoment(this.state, [
-                'start_date',
-                'end_date',
-            ]));
-        }
+        const {initial_visible_month} = convertToMoment(this.props, [
+            'initial_visible_month',
+        ]);
 
+        const {start_date, end_date} = convertToMoment(this.state, [
+            'start_date',
+            'end_date',
+        ]);
         const verticalFlag = calendar_orientation !== 'vertical';
 
         const DatePickerWrapperStyles = {

--- a/src/components/DatePickerRange.react.js
+++ b/src/components/DatePickerRange.react.js
@@ -43,9 +43,10 @@ export default class DatePickerRange extends Component {
     onDatesChange({startDate: start_date, endDate: end_date}) {
         const {setProps, updatemode} = this.props;
 
-        const oldMomentDates = this.props.id
-            ? convertToMoment(this.props, ['start_date', 'end_date'])
-            : convertToMoment(this.state, ['start_date', 'end_date']);
+        const oldMomentDates = convertToMoment(this.state, [
+            'start_date',
+            'end_date',
+        ]);
 
         if (start_date && !start_date.isSame(oldMomentDates.start_date)) {
             if (updatemode === 'singledate') {

--- a/src/components/DatePickerRange.react.js
+++ b/src/components/DatePickerRange.react.js
@@ -22,7 +22,7 @@ export default class DatePickerRange extends Component {
         this.propsToState = this.propsToState.bind(this);
         this.onDatesChange = this.onDatesChange.bind(this);
         this.isOutsideRange = this.isOutsideRange.bind(this);
-        this.state = {focused: false};        
+        this.state = {focused: false};
     }
 
     propsToState(newProps) {

--- a/src/components/DatePickerRange.react.js
+++ b/src/components/DatePickerRange.react.js
@@ -22,6 +22,7 @@ export default class DatePickerRange extends Component {
         this.propsToState = this.propsToState.bind(this);
         this.onDatesChange = this.onDatesChange.bind(this);
         this.isOutsideRange = this.isOutsideRange.bind(this);
+        this.state = {focused: false};        
     }
 
     propsToState(newProps) {

--- a/src/components/DatePickerSingle.react.js
+++ b/src/components/DatePickerSingle.react.js
@@ -39,7 +39,7 @@ export default class DatePickerSingle extends Component {
     }
 
     onDateChange(date) {
-        const {id, setProps} = this.props;
+        const {setProps} = this.props;
         const payload = {date: date ? date.format('YYYY-MM-DD') : null};
         setProps(payload);
     }

--- a/src/components/DatePickerSingle.react.js
+++ b/src/components/DatePickerSingle.react.js
@@ -24,6 +24,7 @@ export default class DatePickerSingle extends Component {
         super();
         this.isOutsideRange = this.isOutsideRange.bind(this);
         this.onDateChange = this.onDateChange.bind(this);
+        this.state = {focused: false};
     }
 
     isOutsideRange(date) {

--- a/src/components/DatePickerSingle.react.js
+++ b/src/components/DatePickerSingle.react.js
@@ -22,40 +22,15 @@ import convertToMoment from '../utils/convertToMoment';
 export default class DatePickerSingle extends Component {
     constructor() {
         super();
-        this.propsToState = this.propsToState.bind(this);
         this.isOutsideRange = this.isOutsideRange.bind(this);
         this.onDateChange = this.onDateChange.bind(this);
     }
 
-    propsToState(newProps) {
-        /*
-         * state includes:
-         * - if no ID, user modifiable attributes (date)
-         * - moment converted attributes
-         */
-
-        const newState = convertToMoment(newProps, [
-            'initial_visible_month',
-            'max_date_allowed',
-            'min_date_allowed',
-        ]);
-
-        if (!newProps.id) {
-            newState.date = newProps.date;
-        }
-        this.setState(newState);
-    }
-
-    componentWillReceiveProps(newProps) {
-        this.propsToState(newProps);
-    }
-
-    componentWillMount() {
-        this.propsToState(this.props);
-    }
-
     isOutsideRange(date) {
-        const {min_date_allowed, max_date_allowed} = this.state;
+        const {max_date_allowed, min_date_allowed} = convertToMoment(
+            this.props,
+            ['max_date_allowed', 'min_date_allowed']
+        );
 
         return (
             (min_date_allowed && date.isBefore(min_date_allowed)) ||
@@ -66,36 +41,11 @@ export default class DatePickerSingle extends Component {
     onDateChange(date) {
         const {id, setProps} = this.props;
         const payload = {date: date ? date.format('YYYY-MM-DD') : null};
-
-        if (!id) {
-            /*
-             * dash-renderer will control this component
-             * if the component has an ID.
-             * If it doesn't, then this component needs to
-             * manage its own state.
-             *
-             * In the future, dash-renderer may be able to
-             * handle the state no matter what:
-             * https://github.com/plotly/dash-renderer/issues/163
-             *
-             * In almost all practical cases, these controls
-             * will have an ID (as they are inputs to callbacks)
-             * but as users are authoring their app's layout,
-             * they may include some controls without IDs
-             * to start. If we don't manage the state, then
-             * the user may be surprised the component reacts
-             * different to user input when it is "unconnected"
-             * (without an ID) vs when it is connected.
-             *
-             */
-            this.setState(payload);
-        } else {
-            setProps(payload);
-        }
+        setProps(payload);
     }
 
     render() {
-        const {focused, initial_visible_month} = this.state;
+        const {focused} = this.state;
 
         const {
             calendar_orientation,
@@ -119,12 +69,10 @@ export default class DatePickerSingle extends Component {
             className,
         } = this.props;
 
-        let date;
-        if (id) {
-            date = convertToMoment(this.props, ['date']).date;
-        } else {
-            date = convertToMoment(this.state, ['date']).date;
-        }
+        const {date, initial_visible_month} = convertToMoment(this.props, [
+            'date',
+            'initial_visible_month',
+        ]);
 
         const verticalFlag = calendar_orientation !== 'vertical';
 

--- a/src/components/Dropdown.react.js
+++ b/src/components/Dropdown.react.js
@@ -34,7 +34,6 @@ export default class Dropdown extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            value: props.value,
             filterOptions: createFilterOptions({
                 options: props.options,
                 tokenizer: TOKENIZER,
@@ -43,7 +42,6 @@ export default class Dropdown extends Component {
     }
 
     componentWillReceiveProps(newProps) {
-        this.setState({value: newProps.value});
         if (newProps.options !== this.props.options) {
             this.setState({
                 filterOptions: createFilterOptions({
@@ -55,8 +53,16 @@ export default class Dropdown extends Component {
     }
 
     render() {
-        const {id, multi, options, setProps, style, loading_state} = this.props;
-        const {filterOptions, value} = this.state;
+        const {
+            id,
+            multi,
+            options,
+            setProps,
+            style,
+            loading_state,
+            value,
+        } = this.props;
+        const {filterOptions} = this.state;
         let selectedValue;
         if (R.type(value) === 'array') {
             selectedValue = value.join(DELIMETER);
@@ -81,12 +87,9 @@ export default class Dropdown extends Component {
                             if (R.isNil(selectedOption)) {
                                 value = [];
                             } else {
-                                value = R.pluck('value', selectedOption);
+                                value = pluck('value', selectedOption);
                             }
-                            this.setState({value});
-                            if (setProps) {
-                                setProps({value});
-                            }
+                            setProps({value});
                         } else {
                             let value;
                             if (R.isNil(selectedOption)) {
@@ -94,10 +97,7 @@ export default class Dropdown extends Component {
                             } else {
                                 value = selectedOption.value;
                             }
-                            this.setState({value});
-                            if (setProps) {
-                                setProps({value});
-                            }
+                            setProps({value});
                         }
                     }}
                     {...omit(['setProps', 'value'], this.props)}

--- a/src/components/Dropdown.react.js
+++ b/src/components/Dropdown.react.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import R, {omit} from 'ramda';
+import {isNil, pluck, omit, type} from 'ramda';
 import React, {Component} from 'react';
 import ReactDropdown from 'react-virtualized-select';
 import createFilterOptions from 'react-select-fast-filter-options';
@@ -64,7 +64,7 @@ export default class Dropdown extends Component {
         } = this.props;
         const {filterOptions} = this.state;
         let selectedValue;
-        if (R.type(value) === 'array') {
+        if (type(value) === 'array') {
             selectedValue = value.join(DELIMETER);
         } else {
             selectedValue = value;
@@ -84,7 +84,7 @@ export default class Dropdown extends Component {
                     onChange={selectedOption => {
                         if (multi) {
                             let value;
-                            if (R.isNil(selectedOption)) {
+                            if (isNil(selectedOption)) {
                                 value = [];
                             } else {
                                 value = pluck('value', selectedOption);
@@ -92,7 +92,7 @@ export default class Dropdown extends Component {
                             setProps({value});
                         } else {
                             let value;
-                            if (R.isNil(selectedOption)) {
+                            if (isNil(selectedOption)) {
                                 value = null;
                             } else {
                                 value = selectedOption.value;

--- a/src/components/Graph.react.js
+++ b/src/components/Graph.react.js
@@ -140,9 +140,7 @@ class PlotlyGraph extends Component {
         gd.on('plotly_click', eventData => {
             const clickData = filterEventData(gd, eventData, 'click');
             if (!isNil(clickData)) {
-                if (setProps) {
-                    setProps({clickData});
-                }
+                setProps({clickData});
             }
         });
         gd.on('plotly_clickannotation', eventData => {
@@ -150,37 +148,27 @@ class PlotlyGraph extends Component {
                 ['event', 'fullAnnotation'],
                 eventData
             );
-            if (setProps) {
-                setProps({clickAnnotationData});
-            }
+            setProps({clickAnnotationData});
         });
         gd.on('plotly_hover', eventData => {
             const hoverData = filterEventData(gd, eventData, 'hover');
             if (!isNil(hoverData)) {
-                if (setProps) {
-                    setProps({hoverData});
-                }
+                setProps({hoverData});
             }
         });
         gd.on('plotly_selected', eventData => {
             const selectedData = filterEventData(gd, eventData, 'selected');
             if (!isNil(selectedData)) {
-                if (setProps) {
-                    setProps({selectedData});
-                }
+                setProps({selectedData});
             }
         });
         gd.on('plotly_deselect', () => {
-            if (setProps) {
-                setProps({selectedData: null});
-            }
+            setProps({selectedData: null});
         });
         gd.on('plotly_relayout', eventData => {
             const relayoutData = filterEventData(gd, eventData, 'relayout');
             if (!isNil(relayoutData)) {
-                if (setProps) {
-                    setProps({relayoutData});
-                }
+                setProps({relayoutData});
             }
         });
         gd.on('plotly_restyle', eventData => {
@@ -191,9 +179,7 @@ class PlotlyGraph extends Component {
         });
         gd.on('plotly_unhover', () => {
             if (clear_on_unhover) {
-                if (setProps) {
-                    setProps({hoverData: null});
-                }
+                setProps({hoverData: null});
             }
         });
     }

--- a/src/components/Input.react.js
+++ b/src/components/Input.react.js
@@ -12,29 +12,24 @@ import {omit, isEmpty} from 'ramda';
 export default class Input extends Component {
     constructor(props) {
         super(props);
-        if (!props.setProps || props.debounce) {
-            this.state = {value: props.value};
-        }
+        this.propsToState = this.propsToState.bind(this);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (this.props.setProps) {
-            this.props = nextProps;
-            if (this.props.debounce) {
-                this.setState({
-                    value: nextProps.value,
-                });
-            }
-        }
+    propsToState(newProps) {
+        this.setState({value: newProps.value});
+    }
+
+    componentWillReceiveProps(newProps) {
+        this.propsToState(newProps);
+    }
+
+    componentWillMount() {
+        this.propsToState(this.props);
     }
 
     render() {
         const {setProps, type, min, max, debounce, loading_state} = this.props;
-        const {value} = setProps
-            ? debounce
-                ? this.state
-                : this.props
-            : this.state;
+        const value = this.state.value;
         return (
             <input
                 data-dash-is-loading={
@@ -48,7 +43,7 @@ export default class Input extends Component {
                     ) {
                         return;
                     }
-                    if (!debounce && setProps) {
+                    if (!debounce) {
                         const castValue =
                             type === 'number' ? Number(newValue) : newValue;
                         setProps({
@@ -59,20 +54,18 @@ export default class Input extends Component {
                     }
                 }}
                 onBlur={() => {
-                    if (setProps) {
-                        const payload = {
-                            n_blur: this.props.n_blur + 1,
-                            n_blur_timestamp: Date.now(),
-                        };
-                        if (debounce) {
-                            payload.value =
-                                type === 'number' ? Number(value) : value;
-                        }
-                        setProps(payload);
+                    const payload = {
+                        n_blur: this.props.n_blur + 1,
+                        n_blur_timestamp: Date.now(),
+                    };
+                    if (debounce) {
+                        payload.value =
+                            type === 'number' ? Number(value) : value;
                     }
+                    setProps(payload);
                 }}
                 onKeyPress={e => {
-                    if (setProps && e.key === 'Enter') {
+                    if (e.key === 'Enter') {
                         const payload = {
                             n_submit: this.props.n_submit + 1,
                             n_submit_timestamp: Date.now(),

--- a/src/components/Interval.react.js
+++ b/src/components/Interval.react.js
@@ -53,7 +53,7 @@ export default class Interval extends Component {
     }
 
     reportInterval() {
-        const {setProps, n_intervals} = this.setProps;
+        const {setProps, n_intervals} = this.props;
         setProps({n_intervals: n_intervals + 1});
     }
 

--- a/src/components/Interval.react.js
+++ b/src/components/Interval.react.js
@@ -23,7 +23,7 @@ export default class Interval extends Component {
             props.n_intervals >= props.max_intervals
         ) {
             // stop existing timer
-            if (this.intervalId()) {
+            if (this.intervalId) {
                 this.clearTimer();
             }
             // and don't start a timer

--- a/src/components/Interval.react.js
+++ b/src/components/Interval.react.js
@@ -20,7 +20,8 @@ export default class Interval extends Component {
         if (
             props.max_intervals === 0 ||
             props.disabled ||
-            props.n_intervals >= props.max_intervals
+            (props.n_intervals >= props.max_intervals &&
+                props.max_intervals != -1)
         ) {
             // stop existing timer
             if (this.intervalId) {

--- a/src/components/Interval.react.js
+++ b/src/components/Interval.react.js
@@ -21,7 +21,7 @@ export default class Interval extends Component {
             props.max_intervals === 0 ||
             props.disabled ||
             (props.n_intervals >= props.max_intervals &&
-                props.max_intervals != -1)
+                props.max_intervals !== -1)
         ) {
             // stop existing timer
             if (this.intervalId) {

--- a/src/components/Loading.react.js
+++ b/src/components/Loading.react.js
@@ -5,7 +5,7 @@ import DefaultSpinner from '../fragments/Loading/spinners/DefaultSpinner.jsx';
 import CubeSpinner from '../fragments/Loading/spinners/CubeSpinner.jsx';
 import CircleSpinner from '../fragments/Loading/spinners/CircleSpinner.jsx';
 import DotSpinner from '../fragments/Loading/spinners/DotSpinner.jsx';
-import R from 'ramda';
+import {type} from 'ramda';
 
 function getSpinner(type) {
     switch (type) {
@@ -52,8 +52,8 @@ export default class Loading extends Component {
         }
 
         if (
-            R.type(this.props.children) !== 'Object' ||
-            R.type(this.props.children) !== 'Function'
+            type(this.props.children) !== 'Object' ||
+            type(this.props.children) !== 'Function'
         ) {
             return <div className={className}>{this.props.children}</div>;
         }

--- a/src/components/Loading.react.js
+++ b/src/components/Loading.react.js
@@ -7,8 +7,8 @@ import CircleSpinner from '../fragments/Loading/spinners/CircleSpinner.jsx';
 import DotSpinner from '../fragments/Loading/spinners/DotSpinner.jsx';
 import {type} from 'ramda';
 
-function getSpinner(type) {
-    switch (type) {
+function getSpinner(spinnerType) {
+    switch (spinnerType) {
         case 'graph':
             return GraphSpinner;
         case 'cube':
@@ -34,11 +34,11 @@ export default class Loading extends Component {
             style,
             fullscreen,
             debug,
-            type,
+            type: spinnerType,
         } = this.props;
 
         if (loading_state && loading_state.is_loading) {
-            const Spinner = getSpinner(type);
+            const Spinner = getSpinner(spinnerType);
             return (
                 <Spinner
                     className={className}

--- a/src/components/Location.react.js
+++ b/src/components/Location.react.js
@@ -1,6 +1,6 @@
 import {Component} from 'react';
 import PropTypes from 'prop-types';
-import R from 'ramda';
+import {type} from 'ramda';
 /* global window:true */
 
 /**
@@ -34,8 +34,8 @@ export default class Location extends Component {
             const propVal = props[fieldName];
 
             if (
-                (R.type(propVal) === 'Undefined' || propVal === null) &&
-                R.type(window.location[fieldName]) !== 'Undefined'
+                (type(propVal) === 'Undefined' || propVal === null) &&
+                type(window.location[fieldName]) !== 'Undefined'
             ) {
                 // propVal is undefined or null, but window.location has this fieldName defined
                 propsToSet[fieldName] = window.location[fieldName];
@@ -62,10 +62,7 @@ export default class Location extends Component {
         const searchUpdated = checkExistsUpdateWindowLocation('search');
 
         // propsToSet has been updated -- batch update to Dash
-        if (
-            R.type(setProps) === 'Function' &&
-            Object.keys(propsToSet).length > 0
-        ) {
+        if (Object.keys(propsToSet).length > 0) {
             setProps(propsToSet);
         }
 
@@ -74,8 +71,8 @@ export default class Location extends Component {
             window.history.pushState({}, '', href);
         } else if (pathnameUpdated || hashUpdated || searchUpdated) {
             // Otherwise, we can mash everything together
-            const searchVal = R.type(search) !== 'Undefined' ? search : '';
-            const hashVal = R.type(hash) !== 'Undefined' ? hash : '';
+            const searchVal = type(search) !== 'Undefined' ? search : '';
+            const hashVal = type(hash) !== 'Undefined' ? hash : '';
             window.history.pushState(
                 {},
                 '',

--- a/src/components/Location.react.js
+++ b/src/components/Location.react.js
@@ -88,14 +88,12 @@ export default class Location extends Component {
         const listener = () => {
             return () => {
                 const {setProps} = this.props;
-                if (setProps) {
-                    setProps({
-                        pathname: window.location.pathname,
-                        href: window.location.href,
-                        hash: window.location.hash,
-                        search: window.location.search,
-                    });
-                }
+                setProps({
+                    pathname: window.location.pathname,
+                    href: window.location.href,
+                    hash: window.location.hash,
+                    search: window.location.search,
+                });
             };
         };
         window.addEventListener('onpopstate', listener());

--- a/src/components/RadioItems.react.js
+++ b/src/components/RadioItems.react.js
@@ -10,15 +10,6 @@ import './css/react-select@1.0.0-rc.3.min.css';
  */
 
 export default class RadioItems extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {value: props.value};
-    }
-
-    componentWillReceiveProps(newProps) {
-        this.setState({value: newProps.value});
-    }
-
     render() {
         const {
             id,
@@ -31,8 +22,8 @@ export default class RadioItems extends Component {
             options,
             setProps,
             loading_state,
+            value,
         } = this.props;
-        const {value} = this.state;
 
         let ids = {};
         if (id) {
@@ -60,10 +51,7 @@ export default class RadioItems extends Component {
                             style={inputStyle}
                             type="radio"
                             onChange={() => {
-                                this.setState({value: option.value});
-                                if (setProps) {
-                                    setProps({value: option.value});
-                                }
+                                setProps({value: option.value});
                             }}
                         />
                         {option.label}

--- a/src/components/RangeSlider.react.js
+++ b/src/components/RangeSlider.react.js
@@ -10,11 +10,19 @@ import {Range} from 'rc-slider';
 export default class RangeSlider extends Component {
     constructor(props) {
         super(props);
-        this.state = {value: props.value};
+        this.propsToState = this.propsToState.bind(this);
+    }
+
+    propsToState(newProps) {
+        this.setState({value: newProps.value});
     }
 
     componentWillReceiveProps(newProps) {
-        this.setState({value: newProps.value});
+        this.propsToState(newProps);
+    }
+
+    componentWillMount() {
+        this.propsToState(this.props);
     }
 
     render() {
@@ -26,7 +34,8 @@ export default class RangeSlider extends Component {
             updatemode,
             vertical,
         } = this.props;
-        const {value} = this.state;
+        const value = this.state.value;
+
         return (
             <div
                 id={id}
@@ -38,18 +47,15 @@ export default class RangeSlider extends Component {
             >
                 <Range
                     onChange={value => {
-                        this.setState({value});
                         if (updatemode === 'drag') {
-                            if (setProps) {
-                                setProps({value});
-                            }
+                            setProps({value});
+                        } else {
+                            this.setState({value});
                         }
                     }}
                     onAfterChange={value => {
                         if (updatemode === 'mouseup') {
-                            if (setProps) {
-                                setProps({value});
-                            }
+                            setProps({value});
                         }
                     }}
                     value={value}

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -10,11 +10,19 @@ import './css/rc-slider@6.1.2.css';
 export default class Slider extends Component {
     constructor(props) {
         super(props);
-        this.state = {value: props.value};
+        this.propsToState = this.propsToState.bind(this);
+    }
+
+    propsToState(newProps) {
+        this.setState({value: newProps.value});
     }
 
     componentWillReceiveProps(newProps) {
-        this.setState({value: newProps.value});
+        this.propsToState(newProps);
+    }
+
+    componentWillMount() {
+        this.propsToState(this.props);
     }
 
     render() {
@@ -26,7 +34,8 @@ export default class Slider extends Component {
             updatemode,
             vertical,
         } = this.props;
-        const {value} = this.state;
+        const value = this.state.value;
+
         return (
             <div
                 id={id}
@@ -38,18 +47,15 @@ export default class Slider extends Component {
             >
                 <ReactSlider
                     onChange={value => {
-                        this.setState({value});
                         if (updatemode === 'drag') {
-                            if (setProps) {
-                                setProps({value});
-                            }
+                            setProps({value});
+                        } else {
+                            this.setState({value});
                         }
                     }}
                     onAfterChange={value => {
                         if (updatemode === 'mouseup') {
-                            if (setProps) {
-                                setProps({value});
-                            }
+                            setProps({value});
                         }
                     }}
                     value={value}

--- a/src/components/Store.react.js
+++ b/src/components/Store.react.js
@@ -156,15 +156,13 @@ export default class Store extends React.Component {
         if (isNil(old) && data) {
             // Initial data mount
             this._backstore.setItem(id, data);
-            if (setProps) {
-                setProps({
-                    modified_timestamp: this._backstore.getModified(id),
-                });
-            }
+            setProps({
+                modified_timestamp: this._backstore.getModified(id),
+            });
             return;
         }
 
-        if (setProps && dataChanged(old, data)) {
+        if (dataChanged(old, data)) {
             setProps({
                 data: old,
                 modified_timestamp: this._backstore.getModified(id),
@@ -182,24 +180,20 @@ export default class Store extends React.Component {
         const {data, id, clear_data, setProps} = this.props;
         if (clear_data) {
             this._backstore.removeItem(id);
-            if (setProps) {
-                setProps({
-                    clear_data: false,
-                    data: null,
-                    modified_timestamp: this._backstore.getModified(id),
-                });
-            }
+            setProps({
+                clear_data: false,
+                data: null,
+                modified_timestamp: this._backstore.getModified(id),
+            });
             return;
         }
         const old = this._backstore.getItem(id);
         // Only set the data if it's not the same data.
         if (dataChanged(data, old)) {
             this._backstore.setItem(id, data);
-            if (setProps) {
-                setProps({
-                    modified_timestamp: this._backstore.getModified(id),
-                });
-            }
+            setProps({
+                modified_timestamp: this._backstore.getModified(id),
+            });
         }
     }
 

--- a/src/components/Tabs.react.js
+++ b/src/components/Tabs.react.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {is, isNil} from 'ramda';
+import {has, is, isNil} from 'ramda';
 
 // EnhancedTab is defined here instead of in Tab.react.js because if exported there,
 // it will mess up the Python imports and metadata.json
@@ -138,15 +138,12 @@ export default class Tabs extends Component {
     valueOrDefault() {
         if (has('value', this.props)) {
             return this.props.value;
-        } else {
-            const children = this.parseChildrenToArray();
-            let value;
-            if (children && children[0].props.children) {
-                return children[0].props.children.props.value || 'tab-1';
-            } else {
-                return 'tab-1';
-            }
         }
+        const children = this.parseChildrenToArray();
+        if (children && children[0].props.children) {
+            return children[0].props.children.props.value || 'tab-1';
+        }
+        return 'tab-1';
     }
 
     parseChildrenToArray() {

--- a/src/components/Tabs.react.js
+++ b/src/components/Tabs.react.js
@@ -132,30 +132,20 @@ export default class Tabs extends Component {
 
         this.selectHandler = this.selectHandler.bind(this);
         this.parseChildrenToArray = this.parseChildrenToArray.bind(this);
+        this.valueOrDefault = this.valueOrDefault.bind(this);
+    }
 
-        if (!this.props.value) {
-            // if no value specified on Tabs component, set it to the first child's (which should be a Tab component) value
-
+    valueOrDefault() {
+        if (has('value', this.props)) {
+            return this.props.value;
+        } else {
             const children = this.parseChildrenToArray();
             let value;
             if (children && children[0].props.children) {
-                value = children[0].props.children.props.value || 'tab-1';
+                return children[0].props.children.props.value || 'tab-1';
             } else {
-                value = 'tab-1';
+                return 'tab-1';
             }
-            this.state = {
-                selected: value,
-            };
-            if (this.props.setProps) {
-                // updating the prop in Dash is necessary so that callbacks work
-                this.props.setProps({
-                    value: value,
-                });
-            }
-        } else {
-            this.state = {
-                selected: this.props.value,
-            };
         }
     }
     parseChildrenToArray() {
@@ -167,21 +157,7 @@ export default class Tabs extends Component {
         return this.props.children;
     }
     selectHandler(value) {
-        if (this.props.setProps) {
-            this.props.setProps({value: value});
-        } else {
-            this.setState({
-                selected: value,
-            });
-        }
-    }
-    componentWillReceiveProps(newProps) {
-        const value = newProps.value;
-        if (typeof value !== 'undefined' && this.props.value !== value) {
-            this.setState({
-                selected: value,
-            });
-        }
+        this.props.setProps({value: value});
     }
     render() {
         let EnhancedTabs;
@@ -219,7 +195,7 @@ export default class Tabs extends Component {
                 }
 
                 // check if this child/Tab is currently selected
-                if (childProps.value === this.state.selected) {
+                if (childProps.value === this.valueOrDefault()) {
                     selectedTab = child;
                 }
 
@@ -228,7 +204,7 @@ export default class Tabs extends Component {
                         key={index}
                         id={childProps.id}
                         label={childProps.label}
-                        selected={this.state.selected === childProps.value}
+                        selected={this.valueOrDefault() === childProps.value}
                         selectHandler={this.selectHandler}
                         className={childProps.className}
                         style={childProps.style}

--- a/src/components/Tabs.react.js
+++ b/src/components/Tabs.react.js
@@ -136,7 +136,7 @@ export default class Tabs extends Component {
 
         if (!has('value', this.props)) {
             this.props.setProps({
-                value: this.valueOrDefault()
+                value: this.valueOrDefault(),
             });
         }
     }

--- a/src/components/Tabs.react.js
+++ b/src/components/Tabs.react.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import R from 'ramda';
+import {is, isNil} from 'ramda';
 
 // EnhancedTab is defined here instead of in Tab.react.js because if exported there,
 // it will mess up the Python imports and metadata.json
@@ -39,7 +39,7 @@ const EnhancedTab = ({
         tabClassName += ` tab--selected ${selectedClassName || ''}`;
     }
     let labelDisplay;
-    if (R.is(Array, label)) {
+    if (is(Array, label)) {
         // label is an array, so it has children that we want to render
         labelDisplay = label[0].props.children;
     } else {
@@ -148,17 +148,20 @@ export default class Tabs extends Component {
             }
         }
     }
+
     parseChildrenToArray() {
-        if (this.props.children && !R.is(Array, this.props.children)) {
+        if (this.props.children && !is(Array, this.props.children)) {
             // if dcc.Tabs.children contains just one single element, it gets passed as an object
             // instead of an array - so we put in in a array ourselves!
             return [this.props.children];
         }
         return this.props.children;
     }
+
     selectHandler(value) {
         this.props.setProps({value: value});
     }
+
     render() {
         let EnhancedTabs;
         let selectedTab;
@@ -173,13 +176,12 @@ export default class Tabs extends Component {
                 // enhance Tab components coming from Dash (as dcc.Tab) with methods needed for handling logic
                 let childProps;
 
-                // TODO: fix issue in dash-renderer https://github.com/plotly/dash-renderer/issues/84
                 if (
                     // disabled is a defaultProp (so it's always set)
                     // meaning that if it's not set on child.props, the actual
                     // props we want are lying a bit deeper - which means they
                     // are coming from Dash
-                    R.isNil(child.props.disabled) &&
+                    isNil(child.props.disabled) &&
                     child.props._dashprivate_layout &&
                     child.props._dashprivate_layout.props
                 ) {
@@ -224,7 +226,7 @@ export default class Tabs extends Component {
             });
         }
 
-        const selectedTabContent = !R.isNil(selectedTab) ? selectedTab : '';
+        const selectedTabContent = !isNil(selectedTab) ? selectedTab : '';
 
         const tabContainerClass = this.props.vertical
             ? 'tab-container tab-container--vert'

--- a/src/components/Tabs.react.js
+++ b/src/components/Tabs.react.js
@@ -133,6 +133,12 @@ export default class Tabs extends Component {
         this.selectHandler = this.selectHandler.bind(this);
         this.parseChildrenToArray = this.parseChildrenToArray.bind(this);
         this.valueOrDefault = this.valueOrDefault.bind(this);
+
+        if (!has('value', this.props)) {
+            this.props.setProps({
+                value: this.valueOrDefault()
+            });
+        }
     }
 
     valueOrDefault() {

--- a/src/components/Textarea.react.js
+++ b/src/components/Textarea.react.js
@@ -7,18 +7,8 @@ import {omit} from 'ramda';
  *
  */
 export default class Textarea extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {value: props.value};
-    }
-
-    componentWillReceiveProps(nextProps) {
-        this.setState({value: nextProps.value});
-    }
-
     render() {
-        const {setProps, loading_state} = this.props;
-        const {value} = this.state;
+        const {setProps, loading_state, value} = this.props;
 
         return (
             <textarea
@@ -27,26 +17,19 @@ export default class Textarea extends Component {
                 }
                 value={value}
                 onChange={e => {
-                    this.setState({value: e.target.value});
-                    if (setProps) {
-                        setProps({value: e.target.value});
-                    }
+                    setProps({value: e.target.value});
                 }}
                 onBlur={() => {
-                    if (setProps) {
-                        setProps({
-                            n_blur: this.props.n_blur + 1,
-                            n_blur_timestamp: Date.now(),
-                        });
-                    }
+                    setProps({
+                        n_blur: this.props.n_blur + 1,
+                        n_blur_timestamp: Date.now(),
+                    });
                 }}
                 onClick={() => {
-                    if (setProps) {
-                        setProps({
-                            n_clicks: this.props.n_clicks + 1,
-                            n_clicks_timestamp: Date.now(),
-                        });
-                    }
+                    setProps({
+                        n_clicks: this.props.n_clicks + 1,
+                        n_clicks_timestamp: Date.now(),
+                    });
                 }}
                 {...omit(['setProps', 'value'], this.props)}
             />

--- a/src/components/Upload.react.js
+++ b/src/components/Upload.react.js
@@ -18,26 +18,24 @@ export default class Upload extends Component {
         files.forEach(file => {
             const reader = new FileReader();
             reader.onload = () => {
-                if (setProps) {
-                    /*
-                     * I'm not sure if reader.onload will be executed in order.
-                     * For example, if the 1st file is larger than the 2nd one,
-                     * the 2nd file might load first.
-                     */
-                    newProps.contents.push(reader.result);
-                    newProps.filename.push(file.name);
-                    // eslint-disable-next-line no-magic-numbers
-                    newProps.last_modified.push(file.lastModified / 1000);
-                    if (newProps.contents.length === files.length) {
-                        if (multiple) {
-                            setProps(newProps);
-                        } else {
-                            setProps({
-                                contents: newProps.contents[0],
-                                filename: newProps.filename[0],
-                                last_modified: newProps.last_modified[0],
-                            });
-                        }
+                /*
+                 * I'm not sure if reader.onload will be executed in order.
+                 * For example, if the 1st file is larger than the 2nd one,
+                 * the 2nd file might load first.
+                 */
+                newProps.contents.push(reader.result);
+                newProps.filename.push(file.name);
+                // eslint-disable-next-line no-magic-numbers
+                newProps.last_modified.push(file.lastModified / 1000);
+                if (newProps.contents.length === files.length) {
+                    if (multiple) {
+                        setProps(newProps);
+                    } else {
+                        setProps({
+                            contents: newProps.contents[0],
+                            filename: newProps.filename[0],
+                            last_modified: newProps.last_modified[0],
+                        });
                     }
                 }
             };

--- a/test/unit/Input.test.js
+++ b/test/unit/Input.test.js
@@ -121,15 +121,11 @@ describe('Input with (default) type=text', () => {
     beforeEach(() => {
         mockSetProps = jest.fn();
 
-        input = mount(
-            <Input value="initial value" setProps={mockSetProps} />
-        );
+        input = mount(<Input value="initial value" setProps={mockSetProps} />);
     });
 
     test('Input will call setProps with value updates if provided', () => {
-        input
-            .find('input')
-            .simulate('change', {target: {value: 'new value'}});
+        input.find('input').simulate('change', {target: {value: 'new value'}});
 
         expect(mockSetProps.mock.calls.length).toEqual(1);
         expect(mockSetProps.mock.calls[0][0]).toEqual({value: 'new value'});
@@ -168,18 +164,14 @@ describe('Input with type=number', () => {
             expect(Number(input.find('input').instance().value)).toEqual(0);
         });
         test('Input can not be updated higher than props.max', () => {
-            input
-                .find('input')
-                .simulate('change', {target: {value: `${3}`}});
+            input.find('input').simulate('change', {target: {value: `${3}`}});
             // if the target value is higher than max, don't even call setProps
             expect(mockSetProps.mock.calls.length).toEqual(0);
             // <input/>'s value should remain the same
             expect(Number(input.find('input').instance().value)).toEqual(0);
         });
         test('Input can be updated normally', () => {
-            input
-                .find('input')
-                .simulate('change', {target: {value: `${1}`}});
+            input.find('input').simulate('change', {target: {value: `${1}`}});
             // if the target value is higher than max, don't even call setProps
             expect(mockSetProps.mock.calls.length).toEqual(1);
             // input's value should remain the same
@@ -195,9 +187,7 @@ describe('Input with type=number', () => {
             );
         });
         test('Input can update normally', () => {
-            input
-                .find('input')
-                .simulate('change', {target: {value: '100'}});
+            input.find('input').simulate('change', {target: {value: '100'}});
             expect(mockSetProps.mock.calls.length).toEqual(1);
             expect(mockSetProps.mock.calls[0][0].value).toEqual(100);
         });

--- a/test/unit/Input.test.js
+++ b/test/unit/Input.test.js
@@ -117,36 +117,6 @@ describe('Props can be set properly', () => {
 });
 
 describe('Input with (default) type=text', () => {
-    describe('Input without setProps() defined', () => {
-        let input;
-        beforeEach(() => {
-            input = mount(<Input value="initial value" />);
-        });
-        test('Input updates value', () => {
-            expect(input.find('input').instance().value).toEqual(
-                'initial value'
-            );
-
-            input
-                .find('input')
-                .simulate('change', {target: {value: 'new value'}});
-
-            expect(input.find('input').instance().value).toEqual('new value');
-        });
-        test('Input does not change state if it rerenders', () => {
-            // dash-renderer could rerender a component with it's original
-            // props, if dash-renderer is not aware of prop changes (that happen with setState
-            // instead of setProps)
-            input.setProps({value: 'new value'});
-
-            // expect value prop to not be updated on state, and on the node itself
-            expect(input.state().value).toEqual('initial value');
-            expect(input.find('input').instance().value).toEqual(
-                'initial value'
-            );
-        });
-    });
-
     describe('Input with setProps() defined', () => {
         let mockSetProps, input;
         beforeEach(() => {
@@ -155,9 +125,6 @@ describe('Input with (default) type=text', () => {
             input = mount(
                 <Input value="initial value" setProps={mockSetProps} />
             );
-        });
-        test('Input does not use state if setProps is defined, and debounce is false', () => {
-            expect(input.state()).toBeFalsy();
         });
 
         test('Input will call setProps with value updates if provided', () => {
@@ -179,53 +146,6 @@ describe('Input with (default) type=text', () => {
 });
 
 describe('Input with type=number', () => {
-    describe('Without setProps(), using this.state', () => {
-        describe('with min and max props', () => {
-            let input;
-            const props = {
-                value: 0,
-                min: 0,
-                max: 2,
-            };
-            beforeEach(() => {
-                input = mount(<Input type="number" {...props} />);
-            });
-            test('Input can not be updated lower than props.min', () => {
-                input
-                    .find('input')
-                    .simulate('change', {target: {value: `${props.min - 1}`}});
-                expect(Number(input.find('input').instance().value)).toEqual(
-                    props.value
-                );
-            });
-            test('Input can not be updated higher than props.max', () => {
-                input
-                    .find('input')
-                    .simulate('change', {target: {value: `${props.max + 1}`}});
-                expect(Number(input.find('input').instance().value)).toEqual(
-                    props.value
-                );
-            });
-        });
-        describe('without min and max props', () => {
-            let input;
-            beforeEach(() => {
-                input = mount(<Input type="number" value={0} />);
-            });
-            test('Input can be updated', () => {
-                input.find('input').simulate('change', {target: {value: '-1'}});
-                expect(Number(input.find('input').instance().value)).toEqual(
-                    -1
-                );
-                input
-                    .find('input')
-                    .simulate('change', {target: {value: '100'}});
-                expect(Number(input.find('input').instance().value)).toEqual(
-                    100
-                );
-            });
-        });
-    });
     describe('With setProps', () => {
         describe('with min and max props', () => {
             let mockSetProps, input;

--- a/test/unit/Input.test.js
+++ b/test/unit/Input.test.js
@@ -117,129 +117,125 @@ describe('Props can be set properly', () => {
 });
 
 describe('Input with (default) type=text', () => {
-    describe('Input with setProps() defined', () => {
-        let mockSetProps, input;
-        beforeEach(() => {
-            mockSetProps = jest.fn();
+    let mockSetProps, input;
+    beforeEach(() => {
+        mockSetProps = jest.fn();
 
-            input = mount(
-                <Input value="initial value" setProps={mockSetProps} />
-            );
-        });
+        input = mount(
+            <Input value="initial value" setProps={mockSetProps} />
+        );
+    });
 
-        test('Input will call setProps with value updates if provided', () => {
-            input
-                .find('input')
-                .simulate('change', {target: {value: 'new value'}});
+    test('Input will call setProps with value updates if provided', () => {
+        input
+            .find('input')
+            .simulate('change', {target: {value: 'new value'}});
 
-            expect(mockSetProps.mock.calls.length).toEqual(1);
-            expect(mockSetProps.mock.calls[0][0]).toEqual({value: 'new value'});
-        });
+        expect(mockSetProps.mock.calls.length).toEqual(1);
+        expect(mockSetProps.mock.calls[0][0]).toEqual({value: 'new value'});
+    });
 
-        test("Input updates it's value on recieving new props", () => {
-            input.setProps({value: 'new value'});
+    test("Input updates it's value on recieving new props", () => {
+        input.setProps({value: 'new value'});
 
-            // expect value prop to not be updated on state, and on the node itself
-            expect(input.find('input').instance().value).toEqual('new value');
-        });
+        // expect value prop to not be updated on state, and on the node itself
+        expect(input.find('input').instance().value).toEqual('new value');
     });
 });
 
 describe('Input with type=number', () => {
-    describe('With setProps', () => {
-        describe('with min and max props', () => {
-            let mockSetProps, input;
-            const props = {
-                value: 0,
-                min: 0,
-                max: 2,
-            };
-            beforeEach(() => {
-                mockSetProps = jest.fn();
-                input = mount(
-                    <Input type="number" {...props} setProps={mockSetProps} />
-                );
-            });
-            test('Input can not be updated lower than props.min', () => {
-                input
-                    .find('input')
-                    .simulate('change', {target: {value: `${props.min - 1}`}});
-
-                // if the target value is lower than min, don't even call setProps
-                expect(mockSetProps.mock.calls.length).toEqual(0);
-                // <input/>'s value should remain the same
-                expect(Number(input.find('input').instance().value)).toEqual(0);
-            });
-            test('Input can not be updated higher than props.max', () => {
-                input
-                    .find('input')
-                    .simulate('change', {target: {value: `${3}`}});
-                // if the target value is higher than max, don't even call setProps
-                expect(mockSetProps.mock.calls.length).toEqual(0);
-                // <input/>'s value should remain the same
-                expect(Number(input.find('input').instance().value)).toEqual(0);
-            });
-            test('Input can be updated normally', () => {
-                input
-                    .find('input')
-                    .simulate('change', {target: {value: `${1}`}});
-                // if the target value is higher than max, don't even call setProps
-                expect(mockSetProps.mock.calls.length).toEqual(1);
-                // input's value should remain the same
-                expect(mockSetProps.mock.calls[0][0].value).toEqual(1);
-            });
+    describe('with min and max props', () => {
+        let mockSetProps, input;
+        const props = {
+            value: 0,
+            min: 0,
+            max: 2,
+        };
+        beforeEach(() => {
+            mockSetProps = jest.fn();
+            input = mount(
+                <Input type="number" {...props} setProps={mockSetProps} />
+            );
         });
-        describe('without min and max props', () => {
-            let mockSetProps, input;
-            beforeEach(() => {
-                mockSetProps = jest.fn();
-                input = mount(
-                    <Input type="number" value={0} setProps={mockSetProps} />
-                );
-            });
-            test('Input can update normally', () => {
+        test('Input can not be updated lower than props.min', () => {
+            input
+                .find('input')
+                .simulate('change', {target: {value: `${props.min - 1}`}});
+
+            // if the target value is lower than min, don't even call setProps
+            expect(mockSetProps.mock.calls.length).toEqual(0);
+            // <input/>'s value should remain the same
+            expect(Number(input.find('input').instance().value)).toEqual(0);
+        });
+        test('Input can not be updated higher than props.max', () => {
+            input
+                .find('input')
+                .simulate('change', {target: {value: `${3}`}});
+            // if the target value is higher than max, don't even call setProps
+            expect(mockSetProps.mock.calls.length).toEqual(0);
+            // <input/>'s value should remain the same
+            expect(Number(input.find('input').instance().value)).toEqual(0);
+        });
+        test('Input can be updated normally', () => {
+            input
+                .find('input')
+                .simulate('change', {target: {value: `${1}`}});
+            // if the target value is higher than max, don't even call setProps
+            expect(mockSetProps.mock.calls.length).toEqual(1);
+            // input's value should remain the same
+            expect(mockSetProps.mock.calls[0][0].value).toEqual(1);
+        });
+    });
+    describe('without min and max props', () => {
+        let mockSetProps, input;
+        beforeEach(() => {
+            mockSetProps = jest.fn();
+            input = mount(
+                <Input type="number" value={0} setProps={mockSetProps} />
+            );
+        });
+        test('Input can update normally', () => {
+            input
+                .find('input')
+                .simulate('change', {target: {value: '100'}});
+            expect(mockSetProps.mock.calls.length).toEqual(1);
+            expect(mockSetProps.mock.calls[0][0].value).toEqual(100);
+        });
+    });
+    describe('with debouncing on', () => {
+        let mockSetProps, input;
+        beforeEach(() => {
+            mockSetProps = jest.fn();
+            input = mount(
+                <Input
+                    type="number"
+                    value={0}
+                    debounce={true}
+                    step={0.01}
+                    setProps={mockSetProps}
+                />
+            );
+        });
+        test('Input debounces update - only fires setProps on submit', () => {
+            // Tests issue #169, where users couldn't input
+            // 0.0 because setProps() would fire immediately, causing
+            // 0.0 to be truncated to 0, making it impossible to input
+            // 0.001 etc
+            // eslint-disable-next-line no-magic-numbers
+            const inputValues = ['0', '0.0', '0.0', '0.001'];
+
+            for (let i = 0; i < inputValues.length; i++) {
                 input
                     .find('input')
-                    .simulate('change', {target: {value: '100'}});
-                expect(mockSetProps.mock.calls.length).toEqual(1);
-                expect(mockSetProps.mock.calls[0][0].value).toEqual(100);
-            });
-        });
-        describe('with debouncing on', () => {
-            let mockSetProps, input;
-            beforeEach(() => {
-                mockSetProps = jest.fn();
-                input = mount(
-                    <Input
-                        type="number"
-                        value={0}
-                        debounce={true}
-                        step={0.01}
-                        setProps={mockSetProps}
-                    />
-                );
-            });
-            test('Input debounces update - only fires setProps on submit', () => {
-                // Tests issue #169, where users couldn't input
-                // 0.0 because setProps() would fire immediately, causing
-                // 0.0 to be truncated to 0, making it impossible to input
-                // 0.001 etc
-                // eslint-disable-next-line no-magic-numbers
-                const inputValues = ['0', '0.0', '0.0', '0.001'];
+                    .simulate('change', {target: {value: inputValues[i]}});
+            }
 
-                for (let i = 0; i < inputValues.length; i++) {
-                    input
-                        .find('input')
-                        .simulate('change', {target: {value: inputValues[i]}});
-                }
+            input.find('input').simulate('keypress', {key: 'Enter'});
 
-                input.find('input').simulate('keypress', {key: 'Enter'});
-
-                expect(mockSetProps.mock.calls.length).toEqual(1);
-                expect(mockSetProps.mock.calls[0][0].value).toEqual(
-                    Number(inputValues[inputValues.length - 1])
-                );
-            });
+            expect(mockSetProps.mock.calls.length).toEqual(1);
+            expect(mockSetProps.mock.calls[0][0].value).toEqual(
+                Number(inputValues[inputValues.length - 1])
+            );
         });
     });
 });

--- a/test/unit/Interval.test.js
+++ b/test/unit/Interval.test.js
@@ -275,12 +275,20 @@ describe('Usage of disabled = true', () => {
         });
 
         describe('After 3 intervals elapsed', () => {
+            /*
+             * Timeline:
+             * 0 - Timer set
+             * 40 - n_intervals = 1  (intervalLength)
+             * 70 - timer disabled   (intervalLength * 2 - intervalNegligibleMargin)
+             * 110 - timer re-enabled
+             * 150 - n_intervals = 2  (... + intervalLength * 2)
+             */
             test('n_intervals = 2', done => {
                 const {results} = makeSut(handleInterval);
                 setTimeout(() => {
                     expect(results.nIntervals).toEqual(2);
                     done();
-                }, intervalLength * 3 + intervalNegligibleMargin);
+                }, intervalLength * 2 - intervalNegligibleMargin + intervalLength * 2 + intervalNegligibleMargin);
             });
         });
     });

--- a/test/unit/Interval.test.js
+++ b/test/unit/Interval.test.js
@@ -25,9 +25,7 @@ class IntervalWrapper extends Component {
                 n_intervals,
             },
             () => {
-                if (this.props.setProps) {
-                    this.props.setProps({n_intervals});
-                }
+                this.props.setProps({n_intervals});
             }
         );
     }
@@ -76,97 +74,6 @@ describe('Basic interval usage', () => {
             </IntervalWrapper>
         );
         const interval = wrapper.childAt(0);
-
-        return {interval, results};
-    };
-
-    test('props.id =>', () => {
-        const {interval} = makeSut();
-        expect(interval.props().id).toEqual('test-interval');
-    });
-
-    describe('t = 0', () => {
-        test('n_intervals = 0', () => {
-            const {results} = makeSut();
-            expect(results.nIntervals).toEqual(0);
-        });
-    });
-
-    describe('After 1 interval elapsed', () => {
-        test('n_intervals = 1', done => {
-            const {results} = makeSut();
-            setTimeout(() => {
-                expect(results.nIntervals).toEqual(1);
-                done();
-            }, intervalLength + intervalNegligibleMargin);
-        });
-    });
-
-    describe('After 2 intervals elapsed', () => {
-        test('n_intervals = 2', done => {
-            const {results} = makeSut();
-            setTimeout(() => {
-                expect(results.nIntervals).toEqual(2);
-                done();
-            }, intervalLength * 2 + intervalNegligibleMargin);
-        });
-    });
-});
-
-describe('Delayed setProps provisioning', () => {
-    class DelayedSetPropsWrapper extends Component {
-        constructor(props) {
-            super(props);
-            this.state = {
-                setPropsProvided: false,
-            };
-        }
-
-        componentDidMount() {
-            this.setState({
-                setPropsProvided: true,
-            });
-        }
-
-        render() {
-            return cloneElement(this.props.children, {
-                ...omit(['children'], this.props),
-                setProps: this.state.setPropsProvided
-                    ? this.props.setProps
-                    : null,
-            });
-        }
-    }
-
-    DelayedSetPropsWrapper.propTypes = {
-        children: PropTypes.node,
-        setProps: PropTypes.func,
-    };
-
-    const makeSut = () => {
-        const results = {
-            nIntervals: 0,
-        };
-
-        const setProps = props => {
-            if ('n_intervals' in props) {
-                results.nIntervals = props.n_intervals;
-            }
-        };
-
-        const defaultProps = {
-            id: 'test-interval',
-            interval: intervalLength,
-        };
-
-        const wrapper = mount(
-            <DelayedSetPropsWrapper setProps={setProps}>
-                <IntervalWrapper>
-                    <Interval {...defaultProps} />
-                </IntervalWrapper>
-            </DelayedSetPropsWrapper>
-        );
-        const interval = wrapper.childAt(0).childAt(0);
 
         return {interval, results};
     };

--- a/test/unit/Tabs.test.js
+++ b/test/unit/Tabs.test.js
@@ -1,6 +1,6 @@
 import Tabs from '../../src/components/Tabs.react.js';
 import Tab from '../../src/components/Tab.react.js';
-import React, {cloneElement} from 'react';
+import React from 'react';
 import {mount, render} from 'enzyme';
 import DashRendererMock from './mocks/DashRendererMock.react.js';
 

--- a/test/unit/Tabs.test.js
+++ b/test/unit/Tabs.test.js
@@ -1,13 +1,17 @@
 import Tabs from '../../src/components/Tabs.react.js';
 import Tab from '../../src/components/Tab.react.js';
-import React from 'react';
+import React, {cloneElement} from 'react';
 import {mount, render} from 'enzyme';
+import DashRendererMock from './mocks/DashRendererMock.react.js';
+
 
 test('Tabs render', () => {
     const tabs = render(
-        <Tabs>
-            <Tab label="test-tab" />
-        </Tabs>
+        <DashRendererMock>
+            <Tabs>
+                <Tab label="test-tab" />
+            </Tabs>
+        </DashRendererMock>
     );
 
     expect(tabs.html()).toBeDefined();
@@ -25,27 +29,29 @@ describe('All props can be set properly', () => {
             background: 'blue',
         },
     };
-    const tabs = mount(
-        <Tabs {...defaultProps}>
-            <Tab value="tab-one" />
-        </Tabs>
+    const app = mount(
+        <DashRendererMock>
+            <Tabs {...defaultProps}>
+                <Tab value="tab-one" />
+            </Tabs>
+        </DashRendererMock>
     );
     test('props.id =>', () => {
-        expect(tabs.props().id).toEqual(defaultProps.id);
+        expect(app.find(Tabs).props().id).toEqual(defaultProps.id);
     });
     test('props.value =>', () => {
-        expect(tabs.props().value).toEqual(defaultProps.value);
+        expect(app.find(Tabs).props().value).toEqual(defaultProps.value);
     });
     test('props.vertical =>', () => {
-        expect(tabs.props().vertical).toEqual(defaultProps.vertical);
+        expect(app.find(Tabs).props().vertical).toEqual(defaultProps.vertical);
     });
     test('props.mobile_breakpoint =>', () => {
-        expect(tabs.props().mobile_breakpoint).toEqual(
+        expect(app.find(Tabs).props().mobile_breakpoint).toEqual(
             defaultProps.mobile_breakpoint
         );
     });
     test('props.colors=>', () => {
-        expect(tabs.props().colors).toEqual(defaultProps.colors);
+        expect(app.find(Tabs).props().colors).toEqual(defaultProps.colors);
     });
 });
 
@@ -54,8 +60,9 @@ describe('Tabs parses inline styles if they are set', () => {
     const testStyle = {
         backgroundColor: testColor,
     };
+    const mockSetProps = jest.fn(value => value);
     const tabs = render(
-        <Tabs id="tabs" style={testStyle} parent_style={testStyle}>
+        <Tabs id="tabs" style={testStyle} parent_style={testStyle} setProps={mockSetProps}>
             <Tab label="test-tab" />
         </Tabs>
     );
@@ -106,56 +113,64 @@ describe('Tabs correctly appends classes', () => {
 describe('Tabs render content correctly', () => {
     test('Tabs render Tab.children in content div', () => {
         const tabs = render(
-            <Tabs id="tabs" value="tab-1">
-                <Tab id="tab-1" value="tab-1" label="Tab 1">
-                    <div>Tab 1 child</div>
-                </Tab>
-                <Tab id="tab-2" value="tab-2" label="Tab 2">
-                    <div>Tab 2 child</div>
-                </Tab>
-            </Tabs>
+            <DashRendererMock>
+                <Tabs id="tabs" value="tab-1">
+                    <Tab id="tab-1" value="tab-1" label="Tab 1">
+                        <div>Tab 1 child</div>
+                    </Tab>
+                    <Tab id="tab-2" value="tab-2" label="Tab 2">
+                        <div>Tab 2 child</div>
+                    </Tab>
+                </Tabs>
+            </DashRendererMock>
         );
         const renderedContent = tabs.find('.tab-content').html();
         expect(renderedContent).toEqual('<div>Tab 1 child</div>');
     });
     test('Tabs render correct Tab.children as selected in Tabs.props.value in content div', () => {
         const tabs = render(
-            <Tabs id="tabs" value="tab-2">
-                <Tab id="tab-1" value="tab-1" label="Tab 1">
-                    <div>Tab 1 child</div>
-                </Tab>
-                <Tab id="tab-2" value="tab-2" label="Tab 2">
-                    <div>Tab 2 child</div>
-                </Tab>
-            </Tabs>
+            <DashRendererMock>
+                <Tabs id="tabs" value="tab-2">
+                    <Tab id="tab-1" value="tab-1" label="Tab 1">
+                        <div>Tab 1 child</div>
+                    </Tab>
+                    <Tab id="tab-2" value="tab-2" label="Tab 2">
+                        <div>Tab 2 child</div>
+                    </Tab>
+                </Tabs>
+            </DashRendererMock>
         );
         const renderedContent = tabs.find('.tab-content').html();
         expect(renderedContent).toEqual('<div>Tab 2 child</div>');
     });
     test('Tabs render Tab.children in content div, even if no Tabs.props.value is given', () => {
         const tabs = render(
-            <Tabs id="tabs">
-                <Tab id="tab-1" value="tab-1" label="Tab 1">
-                    <div>Tab 1 child</div>
-                </Tab>
-                <Tab id="tab-2" value="tab-2" label="Tab 2">
-                    <div>Tab 2 child</div>
-                </Tab>
-            </Tabs>
+            <DashRendererMock>
+                <Tabs id="tabs">
+                    <Tab id="tab-1" value="tab-1" label="Tab 1">
+                        <div>Tab 1 child</div>
+                    </Tab>
+                    <Tab id="tab-2" value="tab-2" label="Tab 2">
+                        <div>Tab 2 child</div>
+                    </Tab>
+                </Tabs>
+            </DashRendererMock>
         );
         const renderedContent = tabs.find('.tab-content').html();
         expect(renderedContent).toEqual('<div>Tab 1 child</div>');
     });
     test('Tabs render Tab.children in content div, even if no Tabs.props.value is given, and Tab components have empty values', () => {
         const tabs = render(
-            <Tabs>
-                <Tab>
-                    <div>Tab 1 child</div>
-                </Tab>
-                <Tab>
-                    <div>Tab 2 child</div>
-                </Tab>
-            </Tabs>
+            <DashRendererMock>
+                <Tabs>
+                    <Tab>
+                        <div>Tab 1 child</div>
+                    </Tab>
+                    <Tab>
+                        <div>Tab 2 child</div>
+                    </Tab>
+                </Tabs>
+            </DashRendererMock>
         );
         const renderedContent = tabs.find('.tab-content').html();
         expect(renderedContent).toEqual('<div>Tab 1 child</div>');
@@ -165,14 +180,16 @@ describe('Tabs handle Tab selection logic', () => {
     let tabs;
     beforeEach(() => {
         tabs = mount(
-            <Tabs id="tabs" value="tab-1">
-                <Tab id="tab-1" value="tab-1" label="Tab 1">
-                    <div>Tab 1 child</div>
-                </Tab>
-                <Tab id="tab-2" value="tab-2" label="Tab 2">
-                    <div>Tab 2 child</div>
-                </Tab>
-            </Tabs>
+            <DashRendererMock>
+                <Tabs id="tabs" value="tab-1">
+                    <Tab id="tab-1" value="tab-1" label="Tab 1">
+                        <div>Tab 1 child</div>
+                    </Tab>
+                    <Tab id="tab-2" value="tab-2" label="Tab 2">
+                        <div>Tab 2 child</div>
+                    </Tab>
+                </Tabs>
+            </DashRendererMock>
         );
     });
     test('Tab can be clicked and will display its content', () => {
@@ -201,38 +218,20 @@ describe('Tabs can be used 2 ways', () => {
         expect(mockSetProps.mock.results[1].value.value).toEqual(
             'custom-tab-2'
         );
-        // expect state to not be updated (default is tab-1)
-        expect(tabs.state().selected).toEqual('tab-1');
 
         tabs.find('[value="custom-tab-1"]').simulate('click');
         expect(mockSetProps).toBeCalledTimes(3);
         expect(mockSetProps.mock.results[2].value.value).toEqual(
             'custom-tab-1'
         );
-        // expect state to not be updated (default is tab-1)
-        expect(tabs.state().selected).toEqual('tab-1');
-    });
-    test('Without Dash callbacks, using internal state', () => {
-        const tabs = mount(
-            <Tabs id="tabs">
-                <Tab value="custom-tab-1" id="tab-1" label="Tab 1">
-                    <div>Tab 1 child</div>
-                </Tab>
-                <Tab value="custom-tab-2" id="tab-2" label="Tab 2">
-                    <div>Tab 2 child</div>
-                </Tab>
-            </Tabs>
-        );
-
-        tabs.find('[value="custom-tab-2"]').simulate('click');
-        expect(tabs.state().selected).toEqual('custom-tab-2');
-
-        tabs.find('[value="custom-tab-1"]').simulate('click');
-        expect(tabs.state().selected).toEqual('custom-tab-1');
     });
 });
 describe('Tabs can have null children', () => {
     test('Try to create a Tabs with null children', () => {
-        mount(<Tabs id="tabs" />);
+        mount(
+            <DashRendererMock>
+                <Tabs id="tabs" />
+            </DashRendererMock>
+        );
     });
 });

--- a/test/unit/Tabs.test.js
+++ b/test/unit/Tabs.test.js
@@ -4,7 +4,6 @@ import React, {cloneElement} from 'react';
 import {mount, render} from 'enzyme';
 import DashRendererMock from './mocks/DashRendererMock.react.js';
 
-
 test('Tabs render', () => {
     const tabs = render(
         <DashRendererMock>
@@ -62,7 +61,12 @@ describe('Tabs parses inline styles if they are set', () => {
     };
     const mockSetProps = jest.fn(value => value);
     const tabs = render(
-        <Tabs id="tabs" style={testStyle} parent_style={testStyle} setProps={mockSetProps}>
+        <Tabs
+            id="tabs"
+            style={testStyle}
+            parent_style={testStyle}
+            setProps={mockSetProps}
+        >
             <Tab label="test-tab" />
         </Tabs>
     );

--- a/test/unit/mocks/DashRendererMock.react.js
+++ b/test/unit/mocks/DashRendererMock.react.js
@@ -1,0 +1,22 @@
+import React, {Component, cloneElement} from 'react';
+import {omit} from 'ramda';
+
+export default class DashRendererMock extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+        this.setProps = this.setProps.bind(this);
+    }
+
+    setProps(newProps) {
+        this.setState(newProps);
+    }
+
+    render() {
+        return cloneElement(this.props.children, {
+            ...omit(['children'], this.props),
+            ...this.state,
+            setProps: this.setProps,
+        });
+    }
+}

--- a/test/unit/mocks/DashRendererMock.react.js
+++ b/test/unit/mocks/DashRendererMock.react.js
@@ -1,4 +1,5 @@
-import React, {Component, cloneElement} from 'react';
+import {Component, cloneElement} from 'react';
+import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 
 export default class DashRendererMock extends Component {
@@ -19,4 +20,8 @@ export default class DashRendererMock extends Component {
             setProps: this.setProps,
         });
     }
+}
+
+DashRendererMock.propTypes = {
+    children: PropTypes.any
 }


### PR DESCRIPTION
This PR:
- Makes several components stateless now that `setProps` is always defined 
- Unifies how certain components maintain their own state until a certain user action triggers a “report” to dash-renderer (e.g. `Slider` with `updatemode=‘mouseup’` or `Input` with `debounce`)
- Cleans up `dcc.Interval` & fixes what I'm considering to be a bug (but we can discuss) - https://github.com/plotly/dash-core-components/pull/536/commits/50275ea3110efe9f78e20fef29e1bff0b7e2d103
- Removes all `import * from ramda`