### PR TITLE
Deleting unused proptype ConfirmDialog.key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Removed
+
+- Removed unused `key` prop from `dcc.ConfirmDialog`
+
+
 ## [0.47.0] - 2019-04-25
 ### Fixed
 - Fixed style regression in DatePickerSingle and DatePickerRange [#518](https://github.com/plotly/dash-core-components/issues/518)

--- a/src/components/ConfirmDialog.react.js
+++ b/src/components/ConfirmDialog.react.js
@@ -84,7 +84,6 @@ ConfirmDialog.propTypes = {
      *  Set to true to send the ConfirmDialog.
      */
     displayed: PropTypes.bool,
-    key: PropTypes.string,
 
     /**
      * Dash-assigned callback that gets fired when the value changes.

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1865,7 +1865,6 @@ class Tests(IntegrationTests):
                 return dcc.ConfirmDialog(
                     displayed=True,
                     id='confirm',
-                    key='confirm-{}'.format(time.time()),
                     message='Please confirm.')
 
         self.startServer(app)


### PR DESCRIPTION
This doesn't seem to be read or written anywhere