### PR TITLE
Checklist: rename `values` prop to `value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Changed `dcc.Checklist` prop `values` to `value`, to match all the other input components [#558](https://github.com/plotly/dash-core-components/pull/558). Also improved prop types for `Dropdown` and `RadioItems` `value` props to consistently accept both strings and numbers.
+
 ## [0.48.0] - 2019-05-15
 ### Added
 - `figure` prop in `dcc.Graph` now accepts a `frames` key
-- Improved the `Dropdown` options description for dash-docs #547
-- Added `optionHeight` prop to `Dropdown` #552
+- Improved the `Dropdown` options description for dash-docs [#547](https://github.com/plotly/dash-core-components/pull/547)
+- Added `optionHeight` prop to `Dropdown` [#552](https://github.com/plotly/dash-core-components/pull/552)
 
 ### Removed
 - Removed unused `key` prop from `dcc.ConfirmDialog`

--- a/demo/Demo.react.js
+++ b/demo/Demo.react.js
@@ -279,7 +279,7 @@ class Controller extends Component {
     constructor() {
         super();
         this.state = {
-            values: ['melons', 'apples']
+            value: ['melons', 'apples']
         };
     }
 
@@ -288,7 +288,7 @@ class Controller extends Component {
             setProps={(props) => {
                 this.setState(props);
             }}
-            values={this.state.values}
+            value={this.state.value}
             {...properties}
         />);
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -71,7 +71,9 @@ module.exports = {
   // ],
 
   // A map from regular expressions to module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+      "\\.(css|less)$": "identity-obj-proxy"
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -2485,7 +2485,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -3508,6 +3508,12 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "check-prop-types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/check-prop-types/-/check-prop-types-1.1.2.tgz",
+      "integrity": "sha512-hGDrZ1yhRgKuP1yzZ5sUX/PPmlKBLOF1GyF0Z008Sienko3BFZmlCXnmq+npRTIL/WlFCUzThyd+F5PQnnT1ug==",
+      "dev": true
+    },
     "cheerio": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
@@ -4123,7 +4129,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
@@ -4222,7 +4228,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
@@ -4516,7 +4522,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
@@ -6486,7 +6492,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -6668,6 +6674,11 @@
           }
         }
       }
+    },
+    "harmony-reflect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
+      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA=="
     },
     "has": {
       "version": "1.0.1",
@@ -6936,6 +6947,14 @@
         "postcss": "^6.0.1"
       }
     },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "requires": {
+        "harmony-reflect": "^1.4.6"
+      }
+    },
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
@@ -7177,7 +7196,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -9031,7 +9050,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -9373,7 +9392,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -9980,7 +9999,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -10007,7 +10026,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -10181,7 +10200,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -10549,7 +10568,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
       "dev": true
     },
     "querystring": {
@@ -11575,7 +11594,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -12231,7 +12250,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6678,7 +6678,8 @@
     "harmony-reflect": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
-      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA=="
+      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==",
+      "dev": true
     },
     "has": {
       "version": "1.0.1",
@@ -6951,6 +6952,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
       "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
       "requires": {
         "harmony-reflect": "^1.4.6"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "license": "MIT",
   "dependencies": {
     "color": "^3.1.0",
-    "identity-obj-proxy": "^3.0.0",
     "moment": "^2.20.1",
     "prop-types": "^15.6.0",
     "ramda": "^0.24.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "color": "^3.1.0",
+    "identity-obj-proxy": "^3.0.0",
     "moment": "^2.20.1",
     "prop-types": "^15.6.0",
     "ramda": "^0.24.1",
@@ -54,6 +55,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.5.0",
     "babel-loader": "^8.0.5",
+    "check-prop-types": "^1.1.2",
     "component-playground": "^3.0.0",
     "copyfiles": "^2.0.0",
     "css-loader": "^1.0.1",
@@ -64,6 +66,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "^7.11.1",
     "exec-sh": "^0.3.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^24.5.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.14.2",

--- a/src/components/Checklist.react.js
+++ b/src/components/Checklist.react.js
@@ -166,4 +166,5 @@ Checklist.defaultProps = {
     labelStyle: {},
     labelClassName: '',
     options: [],
+    values: [],
 };

--- a/src/components/Checklist.react.js
+++ b/src/components/Checklist.react.js
@@ -4,8 +4,8 @@ import React, {Component} from 'react';
 
 /**
  * Checklist is a component that encapsulates several checkboxes.
- * The values and labels of the checklist is specified in the `options`
- * property and the checked items are specified with the `values` property.
+ * The values and labels of the checklist are specified in the `options`
+ * property and the checked items are specified with the `value` property.
  * Each checkbox is rendered as an input with a surrounding label.
  */
 export default class Checklist extends Component {
@@ -21,7 +21,7 @@ export default class Checklist extends Component {
             setProps,
             style,
             loading_state,
-            values,
+            value,
         } = this.props;
 
         return (
@@ -40,19 +40,19 @@ export default class Checklist extends Component {
                         className={labelClassName}
                     >
                         <input
-                            checked={contains(option.value, values)}
+                            checked={contains(option.value, value)}
                             className={inputClassName}
                             disabled={Boolean(option.disabled)}
                             style={inputStyle}
                             type="checkbox"
                             onChange={() => {
-                                let newValues;
-                                if (contains(option.value, values)) {
-                                    newValues = without([option.value], values);
+                                let newValue;
+                                if (contains(option.value, value)) {
+                                    newValue = without([option.value], value);
                                 } else {
-                                    newValues = append(option.value, values);
+                                    newValue = append(option.value, value);
                                 }
-                                setProps({values: newValues});
+                                setProps({value: newValue});
                             }}
                         />
                         {option.label}
@@ -85,7 +85,7 @@ Checklist.propTypes = {
             /**
              * The value of the checkbox. This value
              * corresponds to the items specified in the
-             * `values` property.
+             * `value` property.
              */
             value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
                 .isRequired,
@@ -100,7 +100,7 @@ Checklist.propTypes = {
     /**
      * The currently selected value
      */
-    values: PropTypes.arrayOf(
+    value: PropTypes.arrayOf(
         PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     ),
 
@@ -166,5 +166,5 @@ Checklist.defaultProps = {
     labelStyle: {},
     labelClassName: '',
     options: [],
-    values: [],
+    value: [],
 };

--- a/src/components/Dropdown.react.js
+++ b/src/components/Dropdown.react.js
@@ -130,13 +130,13 @@ Dropdown.propTypes = {
             /**
              * The value of the dropdown. This value
              * corresponds to the items specified in the
-             * `values` property.
+             * `value` property.
              */
             value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
                 .isRequired,
 
             /**
-             * If true, this dropdown is disabled and items can't be selected.
+             * If true, this option is disabled and cannot be selected.
              */
             disabled: PropTypes.bool,
         })
@@ -152,9 +152,10 @@ Dropdown.propTypes = {
      */
     value: PropTypes.oneOfType([
         PropTypes.string,
-        PropTypes.arrayOf(PropTypes.string),
         PropTypes.number,
-        PropTypes.arrayOf(PropTypes.number),
+        PropTypes.arrayOf(
+            PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        ),
     ]),
 
     /**
@@ -175,7 +176,7 @@ Dropdown.propTypes = {
     clearable: PropTypes.bool,
 
     /**
-     * If true, the option is disabled
+     * If true, this dropdown is disabled and the selection cannot be changed.
      */
     disabled: PropTypes.bool,
 

--- a/src/components/RadioItems.react.js
+++ b/src/components/RadioItems.react.js
@@ -84,7 +84,7 @@ RadioItems.propTypes = {
             /**
              * The value of the radio item. This value
              * corresponds to the items specified in the
-             * `values` property.
+             * `value` property.
              */
             value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
                 .isRequired,
@@ -99,7 +99,7 @@ RadioItems.propTypes = {
     /**
      * The currently selected value
      */
-    value: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /**
      * The style of the container (div)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -838,7 +838,7 @@ class Tests(IntegrationTests):
                     {'label': 'San Francisco', 'value': 'SF'},
                     {'label': u'北京', 'value': u'北京'}
                 ],
-                values=['MTL', 'SF']
+                value=['MTL', 'SF']
             ),
 
             html.Label('Text Input'),

--- a/test/unit/Checklist.test.js
+++ b/test/unit/Checklist.test.js
@@ -3,7 +3,6 @@ import React from 'react';
 import {mount, render} from 'enzyme';
 import {validate} from './utils';
 
-
 test('Checklist renders', () => {
     const dd = render(<Checklist />);
 
@@ -16,7 +15,7 @@ describe('Props can be set properly', () => {
         options: [
             {label: 'A', value: 'a'},
             {label: 1, value: 2},
-            {label: 'Disabled', value: 'x', disabled: true}
+            {label: 'Disabled', value: 'x', disabled: true},
         ],
         style: {backgroundColor: 'hotpink'},
         className: 'radio-class',
@@ -34,7 +33,7 @@ describe('Props can be set properly', () => {
     const testProps = Object.assign({}, testPropsNoValue, {value: ['a', 2]});
 
     const checklist = mount(<Checklist {...testProps} />);
-    const checklistNoValue = mount(<Checklist {...testPropsNoValue} />)
+    const checklistNoValue = mount(<Checklist {...testPropsNoValue} />);
 
     test('props are being set', () => {
         validate(Checklist, testProps);
@@ -45,8 +44,9 @@ describe('Props can be set properly', () => {
     test('it works with options but no value supplied', () => {
         validate(Checklist, testPropsNoValue);
         expect(checklistNoValue.props()).toBeDefined();
-        expect(checklistNoValue.props())
-            .toEqual(Object.assign({}, testPropsNoValue, {value: []}));
+        expect(checklistNoValue.props()).toEqual(
+            Object.assign({}, testPropsNoValue, {value: []})
+        );
     });
 
     test('props.id is set as the outer element id', () => {

--- a/test/unit/Checklist.test.js
+++ b/test/unit/Checklist.test.js
@@ -31,7 +31,7 @@ describe('Props can be set properly', () => {
         },
     };
 
-    const testProps = Object.assign({}, testPropsNoValue, {values: ['a', 2]});
+    const testProps = Object.assign({}, testPropsNoValue, {value: ['a', 2]});
 
     const checklist = mount(<Checklist {...testProps} />);
     const checklistNoValue = mount(<Checklist {...testPropsNoValue} />)
@@ -46,7 +46,7 @@ describe('Props can be set properly', () => {
         validate(Checklist, testPropsNoValue);
         expect(checklistNoValue.props()).toBeDefined();
         expect(checklistNoValue.props())
-            .toEqual(Object.assign({}, testPropsNoValue, {values: []}));
+            .toEqual(Object.assign({}, testPropsNoValue, {value: []}));
     });
 
     test('props.id is set as the outer element id', () => {

--- a/test/unit/Checklist.test.js
+++ b/test/unit/Checklist.test.js
@@ -1,0 +1,57 @@
+import Checklist from '../../src/components/Checklist.react.js';
+import React from 'react';
+import {mount, render} from 'enzyme';
+import {validate} from './utils';
+
+
+test('Checklist renders', () => {
+    const dd = render(<Checklist />);
+
+    expect(dd.html()).toBeDefined();
+});
+
+describe('Props can be set properly', () => {
+    const testPropsNoValue = {
+        id: 'radio-1',
+        options: [
+            {label: 'A', value: 'a'},
+            {label: 1, value: 2},
+            {label: 'Disabled', value: 'x', disabled: true}
+        ],
+        style: {backgroundColor: 'hotpink'},
+        className: 'radio-class',
+        inputStyle: {margin: '22px'},
+        inputClassName: 'radio-input-class',
+        labelStyle: {fontSize: '2.0em'},
+        labelClassName: 'radio-label-class',
+        loading_state: {
+            is_loading: false,
+            component_name: '',
+            prop_name: '',
+        },
+    };
+
+    const testProps = Object.assign({}, testPropsNoValue, {values: ['a', 2]});
+
+    const checklist = mount(<Checklist {...testProps} />);
+    const checklistNoValue = mount(<Checklist {...testPropsNoValue} />)
+
+    test('props are being set', () => {
+        validate(Checklist, testProps);
+        expect(checklist.props()).toBeDefined();
+        expect(checklist.props()).toEqual(testProps);
+    });
+
+    test('it works with options but no value supplied', () => {
+        validate(Checklist, testPropsNoValue);
+        expect(checklistNoValue.props()).toBeDefined();
+        expect(checklistNoValue.props())
+            .toEqual(Object.assign({}, testPropsNoValue, {values: []}));
+    });
+
+    test('props.id is set as the outer element id', () => {
+        // test if id is in the actual HTML string
+        const ddTag = checklist.render();
+        expect(ddTag.attr('id')).toEqual(testProps.id);
+    });
+});

--- a/test/unit/Dropdown.test.js
+++ b/test/unit/Dropdown.test.js
@@ -1,0 +1,59 @@
+import Dropdown from '../../src/components/Dropdown.react.js';
+import React from 'react';
+import {mount, render} from 'enzyme';
+import {validate} from './utils';
+
+
+test('Dropdown renders', () => {
+    const dd = render(<Dropdown />);
+
+    expect(dd.html()).toBeDefined();
+});
+
+describe('Props can be set properly', () => {
+    const singleProps = {
+        id: 'dd-1',
+        options: [
+            {label: 'A', value: 'a'},
+            {label: 1, value: 2},
+            {label: 'Disabled', value: 'x', disabled: true}
+        ],
+        value: 2,
+        optionHeight: 50,
+        className: 'dd-class',
+        clearable: true,
+        disabled: true,
+        multi: false,
+        placeholder: 'pick something',
+        searchable: true,
+        style: {backgroundColor: 'hotpink'},
+        loading_state: {
+            is_loading: false,
+            component_name: '',
+            prop_name: '',
+        },
+    };
+
+    const multiProps = Object.assign({}, singleProps, {
+        multi: true,
+        value: ['a', 2]
+    });
+    const singleDD = mount(<Dropdown {...singleProps} />);
+    const multiDD = mount(<Dropdown {...multiProps} />);
+
+    test('props are being set', () => {
+        validate(Dropdown, singleProps);
+        expect(singleDD.props()).toBeDefined();
+        expect(singleDD.props()).toEqual(singleProps);
+
+        validate(Dropdown, multiProps);
+        expect(multiDD.props()).toBeDefined();
+        expect(multiDD.props()).toEqual(multiProps);
+    });
+
+    test('props.id is set as the outer element id', () => {
+        // test if id is in the actual HTML string
+        const ddTag = singleDD.render();
+        expect(ddTag.attr('id')).toEqual(singleProps.id);
+    });
+});

--- a/test/unit/Dropdown.test.js
+++ b/test/unit/Dropdown.test.js
@@ -3,7 +3,6 @@ import React from 'react';
 import {mount, render} from 'enzyme';
 import {validate} from './utils';
 
-
 test('Dropdown renders', () => {
     const dd = render(<Dropdown />);
 
@@ -16,7 +15,7 @@ describe('Props can be set properly', () => {
         options: [
             {label: 'A', value: 'a'},
             {label: 1, value: 2},
-            {label: 'Disabled', value: 'x', disabled: true}
+            {label: 'Disabled', value: 'x', disabled: true},
         ],
         value: 2,
         optionHeight: 50,
@@ -36,7 +35,7 @@ describe('Props can be set properly', () => {
 
     const multiProps = Object.assign({}, singleProps, {
         multi: true,
-        value: ['a', 2]
+        value: ['a', 2],
     });
     const singleDD = mount(<Dropdown {...singleProps} />);
     const multiDD = mount(<Dropdown {...multiProps} />);

--- a/test/unit/RadioItems.test.js
+++ b/test/unit/RadioItems.test.js
@@ -3,7 +3,6 @@ import React from 'react';
 import {mount, render} from 'enzyme';
 import {validate} from './utils';
 
-
 test('RadioItems renders', () => {
     const dd = render(<RadioItems />);
 
@@ -16,7 +15,7 @@ describe('Props can be set properly', () => {
         options: [
             {label: 'A', value: 'a'},
             {label: 1, value: 2},
-            {label: 'Disabled', value: 'x', disabled: true}
+            {label: 'Disabled', value: 'x', disabled: true},
         ],
         value: 2,
         style: {backgroundColor: 'hotpink'},

--- a/test/unit/RadioItems.test.js
+++ b/test/unit/RadioItems.test.js
@@ -1,0 +1,48 @@
+import RadioItems from '../../src/components/RadioItems.react.js';
+import React from 'react';
+import {mount, render} from 'enzyme';
+import {validate} from './utils';
+
+
+test('RadioItems renders', () => {
+    const dd = render(<RadioItems />);
+
+    expect(dd.html()).toBeDefined();
+});
+
+describe('Props can be set properly', () => {
+    const testProps = {
+        id: 'radio-1',
+        options: [
+            {label: 'A', value: 'a'},
+            {label: 1, value: 2},
+            {label: 'Disabled', value: 'x', disabled: true}
+        ],
+        value: 2,
+        style: {backgroundColor: 'hotpink'},
+        className: 'radio-class',
+        inputStyle: {margin: '22px'},
+        inputClassName: 'radio-input-class',
+        labelStyle: {fontSize: '2.0em'},
+        labelClassName: 'radio-label-class',
+        loading_state: {
+            is_loading: false,
+            component_name: '',
+            prop_name: '',
+        },
+    };
+
+    const radio = mount(<RadioItems {...testProps} />);
+
+    test('props are being set', () => {
+        validate(RadioItems, testProps);
+        expect(radio.props()).toBeDefined();
+        expect(radio.props()).toEqual(testProps);
+    });
+
+    test('props.id is set as the outer element id', () => {
+        // test if id is in the actual HTML string
+        const ddTag = radio.render();
+        expect(ddTag.attr('id')).toEqual(testProps.id);
+    });
+});

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,14 @@
+import checkPropTypes from 'check-prop-types';
+
+export function validate(component, props) {
+    const errorMessage = checkPropTypes(
+        component.propTypes,
+        props,
+        'prop',
+        component.name
+    );
+
+    if (errorMessage) {
+        throw new Error(errorMessage);
+    }
+}


### PR DESCRIPTION
This is one of the breaking changes planned for the Dash 1.0 release.

Also a couple of little prop type & doc fixes for the `value` prop in `Dropdown` and `RadioItems`.