### PR TITLE
Slider tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Ability to add tooltips to `Slider` and `RangeSlider`, which can be visible always or on hover. Tooltips also take a position argument. [#564]
+- Ability to add tooltips to `Slider` and `RangeSlider`, which can be visible always or on hover. Tooltips also take a position argument. [#564](https://github.com/plotly/dash-core-components/pull/564)
 
 ### Fixed
 - Fixed `min_date_allowed` and `max_date_allowed` bug in `DatePickerRange` [#551]https://github.com/plotly/dash-core-components/issues/551)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Ability to add tooltips to `Slider` and `RangeSlider`, which can be visible always or on hover. Tooltips also take a position argument. [#564]
+
 ### Fixed
 - Fixed `min_date_allowed` and `max_date_allowed` bug in `DatePickerRange` [#551]https://github.com/plotly/dash-core-components/issues/551)
 - Fixed unwanted `resize()` calls on unmounted `Graph`s [#534](https://github.com/plotly/dash-core-components/issues/534)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "moment": "^2.20.1",
     "prop-types": "^15.6.0",
     "ramda": "^0.24.1",
-    "rc-slider": "^8.3.1",
+    "rc-slider": "^8.6.11",
     "react-addons-shallow-compare": "^15.6.0",
     "react-dates": "^20.1.0",
     "react-docgen": "^3.0.0",

--- a/src/components/RangeSlider.react.js
+++ b/src/components/RangeSlider.react.js
@@ -159,7 +159,6 @@ RangeSlider.propTypes = {
     pushable: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
 
     tooltip: PropTypes.exact({
-
        /**
         * Determines whether tooltips should always be visible
         * (as opposed to the default, visible on hover)

--- a/src/components/RangeSlider.react.js
+++ b/src/components/RangeSlider.react.js
@@ -12,8 +12,8 @@ export default class RangeSlider extends Component {
         super(props);
         this.propsToState = this.propsToState.bind(this);
         this.DashSlider = props.tooltip
-          ? createSliderWithTooltip(Range)
-          : Range;
+            ? createSliderWithTooltip(Range)
+            : Range;
     }
 
     propsToState(newProps) {
@@ -163,7 +163,7 @@ RangeSlider.propTypes = {
          * (as opposed to the default, visible on hover)
          */
         PropTypes.exact({
-            visible: PropTypes.oneOf(['visible', 'hover']).isRequired
+            visible: PropTypes.bool.isRequired,
         }),
 
         /**
@@ -173,13 +173,31 @@ RangeSlider.propTypes = {
          * in reality appear to be on the top right of the handle
          */
         PropTypes.exact({
-            position: PropTypes.oneOf(['left','right','top','bottom', 'topLeft', 'topRight', 'bottomLeft', 'bottomRight']).isRequired
+            position: PropTypes.oneOf([
+                'left',
+                'right',
+                'top',
+                'bottom',
+                'topLeft',
+                'topRight',
+                'bottomLeft',
+                'bottomRight',
+            ]).isRequired,
         }),
 
         PropTypes.exact({
-            visible: PropTypes.oneOf(['visible', 'hover']),
-            position: PropTypes.oneOf(['left','right','top','bottom', 'topLeft', 'topRight', 'bottomLeft', 'bottomRight'])
-        })
+            visible: PropTypes.bool,
+            position: PropTypes.oneOf([
+                'left',
+                'right',
+                'top',
+                'bottom',
+                'topLeft',
+                'topRight',
+                'bottomLeft',
+                'bottomRight',
+            ]),
+        }),
     ]),
 
     /**

--- a/src/components/RangeSlider.react.js
+++ b/src/components/RangeSlider.react.js
@@ -11,6 +11,9 @@ export default class RangeSlider extends Component {
     constructor(props) {
         super(props);
         this.propsToState = this.propsToState.bind(this);
+        this.DashSlider = props.tooltip
+          ? createSliderWithTooltip(Range)
+          : Range;
     }
 
     propsToState(newProps) {
@@ -37,10 +40,6 @@ export default class RangeSlider extends Component {
         } = this.props;
         const value = this.state.value;
 
-        const DashSlider = tooltip
-          ? createSliderWithTooltip(Range)
-          : Range;
-
         return (
             <div
                 id={id}
@@ -50,7 +49,7 @@ export default class RangeSlider extends Component {
                 className={className}
                 style={vertical ? {height: '100%'} : {}}
             >
-                <DashSlider
+                <this.DashSlider
                     onChange={value => {
                         if (updatemode === 'drag') {
                             setProps({value});
@@ -158,15 +157,30 @@ RangeSlider.propTypes = {
      */
     pushable: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
 
-    /**
-     * Object that holds optional tooltip parameters
-     */
-    tooltip: PropTypes.shape({
+    tooltip: PropTypes.oneOfType([
         /**
          * Determines whether tooltips should always be visible
+         * (as opposed to the default, visible on hover)
          */
-        visible: PropTypes.bool,
-    }),
+        PropTypes.exact({
+            visible: PropTypes.oneOf(['visible', 'hover']).isRequired
+        }),
+
+        /**
+         * Determines the position of tooltips
+         * See https://github.com/react-component/tooltip#api
+         * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
+         * in reality appear to be on the top right of the handle
+         */
+        PropTypes.exact({
+            position: PropTypes.oneOf(['left','right','top','bottom', 'topLeft', 'topRight', 'bottomLeft', 'bottomRight']).isRequired
+        }),
+
+        PropTypes.exact({
+            visible: PropTypes.oneOf(['visible', 'hover']),
+            position: PropTypes.oneOf(['left','right','top','bottom', 'topLeft', 'topRight', 'bottomLeft', 'bottomRight'])
+        })
+    ]),
 
     /**
      * Value by which increments or decrements are made

--- a/src/components/RangeSlider.react.js
+++ b/src/components/RangeSlider.react.js
@@ -47,7 +47,7 @@ export default class RangeSlider extends Component {
                 data-dash-is-loading={
                     (loading_state && loading_state.is_loading) || undefined
                 }
-                className={className + ' desu'}
+                className={className}
                 style={vertical ? {height: '100%'} : {}}
             >
                 <DashSlider
@@ -169,24 +169,6 @@ RangeSlider.propTypes = {
     }),
 
     /**
-     * Object that holds the loading state object coming from dash-renderer
-     */
-    loading_state: PropTypes.shape({
-        /**
-         * Determines if the component is loading or not
-         */
-        is_loading: PropTypes.bool,
-        /**
-         * Holds which property is loading
-         */
-        prop_name: PropTypes.string,
-        /**
-         * Holds the name of the component that is loading
-         */
-        component_name: PropTypes.string,
-    }),
-
-    /**
      * Value by which increments or decrements are made
      */
     step: PropTypes.number,
@@ -211,6 +193,24 @@ RangeSlider.propTypes = {
      * Dash-assigned callback that gets fired when the value changes.
      */
     setProps: PropTypes.func,
+
+    /**
+     * Object that holds the loading state object coming from dash-renderer
+     */
+    loading_state: PropTypes.shape({
+        /**
+         * Determines if the component is loading or not
+         */
+        is_loading: PropTypes.bool,
+        /**
+         * Holds which property is loading
+         */
+        prop_name: PropTypes.string,
+        /**
+         * Holds the name of the component that is loading
+         */
+        component_name: PropTypes.string,
+    }),
 };
 
 RangeSlider.defaultProps = {

--- a/src/components/RangeSlider.react.js
+++ b/src/components/RangeSlider.react.js
@@ -11,9 +11,6 @@ export default class RangeSlider extends Component {
     constructor(props) {
         super(props);
         this.propsToState = this.propsToState.bind(this);
-        this.DashSlider = props.tooltip
-            ? createSliderWithTooltip(Range)
-            : Range;
     }
 
     propsToState(newProps) {
@@ -40,6 +37,10 @@ export default class RangeSlider extends Component {
         } = this.props;
         const value = this.state.value;
 
+        const DashSlider = tooltip
+            ? createSliderWithTooltip(Range)
+            : Range;
+
         return (
             <div
                 id={id}
@@ -49,7 +50,7 @@ export default class RangeSlider extends Component {
                 className={className}
                 style={vertical ? {height: '100%'} : {}}
             >
-                <this.DashSlider
+                <DashSlider
                     onChange={value => {
                         if (updatemode === 'drag') {
                             setProps({value});

--- a/src/components/RangeSlider.react.js
+++ b/src/components/RangeSlider.react.js
@@ -157,48 +157,31 @@ RangeSlider.propTypes = {
      */
     pushable: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
 
-    tooltip: PropTypes.oneOfType([
-        /**
-         * Determines whether tooltips should always be visible
-         * (as opposed to the default, visible on hover)
-         */
-        PropTypes.exact({
-            visible: PropTypes.bool.isRequired,
-        }),
+    tooltip: PropTypes.exact({
+
+       /**
+        * Determines whether tooltips should always be visible
+        * (as opposed to the default, visible on hover)
+        */
+        visible: PropTypes.bool,
 
         /**
-         * Determines the position of tooltips
-         * See https://github.com/react-component/tooltip#api
-         * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
-         * in reality appear to be on the top right of the handle
-         */
-        PropTypes.exact({
-            position: PropTypes.oneOf([
-                'left',
-                'right',
-                'top',
-                'bottom',
-                'topLeft',
-                'topRight',
-                'bottomLeft',
-                'bottomRight',
-            ]).isRequired,
-        }),
-
-        PropTypes.exact({
-            visible: PropTypes.bool,
-            position: PropTypes.oneOf([
-                'left',
-                'right',
-                'top',
-                'bottom',
-                'topLeft',
-                'topRight',
-                'bottomLeft',
-                'bottomRight',
-            ]),
-        }),
-    ]),
+        * Determines the position of tooltips
+        * See https://github.com/react-component/tooltip#api
+        * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
+        * in reality appear to be on the top right of the handle
+        */
+        position: PropTypes.oneOf([
+            'left',
+            'right',
+            'top',
+            'bottom',
+            'topLeft',
+            'topRight',
+            'bottomLeft',
+            'bottomRight',
+        ]),
+    }),
 
     /**
      * Value by which increments or decrements are made

--- a/src/components/RangeSlider.react.js
+++ b/src/components/RangeSlider.react.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
-import {Range} from 'rc-slider';
+import {Range, createSliderWithTooltip} from 'rc-slider';
 
 /**
  * A double slider with two handles.
@@ -31,10 +31,15 @@ export default class RangeSlider extends Component {
             id,
             loading_state,
             setProps,
+            tooltip,
             updatemode,
             vertical,
         } = this.props;
         const value = this.state.value;
+
+        const DashSlider = tooltip
+          ? createSliderWithTooltip(Range)
+          : Range;
 
         return (
             <div
@@ -42,10 +47,10 @@ export default class RangeSlider extends Component {
                 data-dash-is-loading={
                     (loading_state && loading_state.is_loading) || undefined
                 }
-                className={className}
+                className={className + ' desu'}
                 style={vertical ? {height: '100%'} : {}}
             >
-                <Range
+                <DashSlider
                     onChange={value => {
                         if (updatemode === 'drag') {
                             setProps({value});
@@ -58,6 +63,7 @@ export default class RangeSlider extends Component {
                             setProps({value});
                         }
                     }}
+                    tipProps={tooltip}
                     value={value}
                     {...omit(
                         ['className', 'value', 'setProps', 'updatemode'],
@@ -153,6 +159,34 @@ RangeSlider.propTypes = {
     pushable: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
 
     /**
+     * Object that holds optional tooltip parameters
+     */
+    tooltip: PropTypes.shape({
+        /**
+         * Determines whether tooltips should always be visible
+         */
+        visible: PropTypes.bool,
+    }),
+
+    /**
+     * Object that holds the loading state object coming from dash-renderer
+     */
+    loading_state: PropTypes.shape({
+        /**
+         * Determines if the component is loading or not
+         */
+        is_loading: PropTypes.bool,
+        /**
+         * Holds which property is loading
+         */
+        prop_name: PropTypes.string,
+        /**
+         * Holds the name of the component that is loading
+         */
+        component_name: PropTypes.string,
+    }),
+
+    /**
      * Value by which increments or decrements are made
      */
     step: PropTypes.number,
@@ -177,24 +211,6 @@ RangeSlider.propTypes = {
      * Dash-assigned callback that gets fired when the value changes.
      */
     setProps: PropTypes.func,
-
-    /**
-     * Object that holds the loading state object coming from dash-renderer
-     */
-    loading_state: PropTypes.shape({
-        /**
-         * Determines if the component is loading or not
-         */
-        is_loading: PropTypes.bool,
-        /**
-         * Holds which property is loading
-         */
-        prop_name: PropTypes.string,
-        /**
-         * Holds the name of the component that is loading
-         */
-        component_name: PropTypes.string,
-    }),
 };
 
 RangeSlider.defaultProps = {

--- a/src/components/RangeSlider.react.js
+++ b/src/components/RangeSlider.react.js
@@ -39,6 +39,21 @@ export default class RangeSlider extends Component {
 
         const DashSlider = tooltip ? createSliderWithTooltip(Range) : Range;
 
+        let tipProps;
+        if (tooltip && tooltip.always_visible) {
+            /**
+             * clone `tooltip` but with renamed key `always_visible` -> `visible`
+             * the rc-tooltip API uses `visible`, but `always_visible is more semantic
+             * assigns the new (renamed) key to the old key and deletes the old key
+             */
+            tipProps = Object.assign(tooltip, {
+                visible: tooltip.always_visible
+            })
+            delete tipProps.always_visible;
+        } else {
+            tipProps = tooltip;
+        }
+
         return (
             <div
                 id={id}
@@ -61,7 +76,7 @@ export default class RangeSlider extends Component {
                             setProps({value});
                         }
                     }}
-                    tipProps={tooltip}
+                    tipProps={tipProps}
                     value={value}
                     {...omit(
                         ['className', 'value', 'setProps', 'updatemode'],
@@ -161,15 +176,15 @@ RangeSlider.propTypes = {
          * Determines whether tooltips should always be visible
          * (as opposed to the default, visible on hover)
          */
-        visible: PropTypes.bool,
+        always_visible: PropTypes.bool,
 
         /**
-         * Determines the position of tooltips
+         * Determines the placement of tooltips
          * See https://github.com/react-component/tooltip#api
          * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
          * in reality appear to be on the top right of the handle
          */
-        position: PropTypes.oneOf([
+        placement: PropTypes.oneOf([
             'left',
             'right',
             'top',

--- a/src/components/RangeSlider.react.js
+++ b/src/components/RangeSlider.react.js
@@ -11,6 +11,9 @@ export default class RangeSlider extends Component {
     constructor(props) {
         super(props);
         this.propsToState = this.propsToState.bind(this);
+        this.DashSlider = props.tooltip
+            ? createSliderWithTooltip(Range)
+            : Range;
     }
 
     propsToState(newProps) {
@@ -18,6 +21,11 @@ export default class RangeSlider extends Component {
     }
 
     componentWillReceiveProps(newProps) {
+        if (newProps.tooltip !== this.props.tooltip) {
+            this.DashSlider = newProps.tooltip
+                ? createSliderWithTooltip(Range)
+                : Range;
+        }
         this.propsToState(newProps);
     }
 
@@ -37,8 +45,6 @@ export default class RangeSlider extends Component {
         } = this.props;
         const value = this.state.value;
 
-        const DashSlider = tooltip ? createSliderWithTooltip(Range) : Range;
-
         let tipProps;
         if (tooltip && tooltip.always_visible) {
             /**
@@ -47,8 +53,8 @@ export default class RangeSlider extends Component {
              * assigns the new (renamed) key to the old key and deletes the old key
              */
             tipProps = Object.assign(tooltip, {
-                visible: tooltip.always_visible
-            })
+                visible: tooltip.always_visible,
+            });
             delete tipProps.always_visible;
         } else {
             tipProps = tooltip;
@@ -63,7 +69,7 @@ export default class RangeSlider extends Component {
                 className={className}
                 style={vertical ? {height: '100%'} : {}}
             >
-                <DashSlider
+                <this.DashSlider
                     onChange={value => {
                         if (updatemode === 'drag') {
                             setProps({value});

--- a/src/components/RangeSlider.react.js
+++ b/src/components/RangeSlider.react.js
@@ -37,9 +37,7 @@ export default class RangeSlider extends Component {
         } = this.props;
         const value = this.state.value;
 
-        const DashSlider = tooltip
-            ? createSliderWithTooltip(Range)
-            : Range;
+        const DashSlider = tooltip ? createSliderWithTooltip(Range) : Range;
 
         return (
             <div
@@ -159,18 +157,18 @@ RangeSlider.propTypes = {
     pushable: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
 
     tooltip: PropTypes.exact({
-       /**
-        * Determines whether tooltips should always be visible
-        * (as opposed to the default, visible on hover)
-        */
+        /**
+         * Determines whether tooltips should always be visible
+         * (as opposed to the default, visible on hover)
+         */
         visible: PropTypes.bool,
 
         /**
-        * Determines the position of tooltips
-        * See https://github.com/react-component/tooltip#api
-        * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
-        * in reality appear to be on the top right of the handle
-        */
+         * Determines the position of tooltips
+         * See https://github.com/react-component/tooltip#api
+         * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
+         * in reality appear to be on the top right of the handle
+         */
         position: PropTypes.oneOf([
             'left',
             'right',

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -140,7 +140,6 @@ Slider.propTypes = {
     max: PropTypes.number,
 
     tooltip: PropTypes.exact({
-
        /**
         * Determines whether tooltips should always be visible
         * (as opposed to the default, visible on hover)

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -142,12 +142,22 @@ Slider.propTypes = {
     /**
      * Object that holds optional tooltip parameters
      */
-    tooltip: PropTypes.shape({
+    tooltip: PropTypes.oneOfType([
+
+        // TODO: variations on PropTypes.exact
+
         /**
          * Determines whether tooltips should always be visible
          */
-        visible: PropTypes.bool,
-    }),
+        PropTypes.exact({
+            visible: PropTypes.oneOf(['visible', 'hover'])
+        }),
+
+        PropTypes.exact([
+            visible: PropTypes.oneOf(['visible', 'hover']),
+            position: PropTypes.oneOf(['top', 'hover'])
+        ])
+    ]),
 
     /**
      * Value by which increments or decrements are made

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -138,48 +138,31 @@ Slider.propTypes = {
      */
     max: PropTypes.number,
 
-    tooltip: PropTypes.oneOfType([
-        /**
-         * Determines whether tooltips should always be visible
-         * (as opposed to the default, visible on hover)
-         */
-        PropTypes.exact({
-            visible: PropTypes.bool.isRequired,
-        }),
+    tooltip: PropTypes.exact({
+
+       /**
+        * Determines whether tooltips should always be visible
+        * (as opposed to the default, visible on hover)
+        */
+        visible: PropTypes.bool,
 
         /**
-         * Determines the position of tooltips
-         * See https://github.com/react-component/tooltip#api
-         * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
-         * in reality appear to be on the top right of the handle
-         */
-        PropTypes.exact({
-            position: PropTypes.oneOf([
-                'left',
-                'right',
-                'top',
-                'bottom',
-                'topLeft',
-                'topRight',
-                'bottomLeft',
-                'bottomRight',
-            ]).isRequired,
-        }),
-
-        PropTypes.exact({
-            visible: PropTypes.oneOf(['visible', 'hover']),
-            position: PropTypes.oneOf([
-                'left',
-                'right',
-                'top',
-                'bottom',
-                'topLeft',
-                'topRight',
-                'bottomLeft',
-                'bottomRight',
-            ]),
-        }),
-    ]),
+        * Determines the position of tooltips
+        * See https://github.com/react-component/tooltip#api
+        * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
+        * in reality appear to be on the top right of the handle
+        */
+        position: PropTypes.oneOf([
+            'left',
+            'right',
+            'top',
+            'bottom',
+            'topLeft',
+            'topRight',
+            'bottomLeft',
+            'bottomRight',
+        ]),
+    }),
 
     /**
      * Value by which increments or decrements are made

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import ReactSlider from 'rc-slider';
+import ReactSlider, {createSliderWithTooltip} from 'rc-slider';
 import PropTypes from 'prop-types';
 import {omit} from 'ramda';
 import './css/rc-slider@6.1.2.css';
@@ -31,10 +31,15 @@ export default class Slider extends Component {
             id,
             loading_state,
             setProps,
+            tooltip,
             updatemode,
             vertical,
         } = this.props;
         const value = this.state.value;
+
+        const DashSlider = tooltip
+          ? createSliderWithTooltip(ReactSlider)
+          : ReactSlider;
 
         return (
             <div
@@ -45,7 +50,7 @@ export default class Slider extends Component {
                 className={className}
                 style={vertical ? {height: '100%'} : {}}
             >
-                <ReactSlider
+                <DashSlider
                     onChange={value => {
                         if (updatemode === 'drag') {
                             setProps({value});
@@ -58,6 +63,7 @@ export default class Slider extends Component {
                             setProps({value});
                         }
                     }}
+                    tipProps={tooltip}
                     value={value}
                     {...omit(
                         ['className', 'setProps', 'updatemode', 'value'],
@@ -132,6 +138,16 @@ Slider.propTypes = {
      * Maximum allowed value of the slider
      */
     max: PropTypes.number,
+
+    /**
+     * Object that holds optional tooltip parameters
+     */
+    tooltip: PropTypes.shape({
+        /**
+         * Determines whether tooltips should always be visible
+         */
+        visible: PropTypes.bool,
+    }),
 
     /**
      * Value by which increments or decrements are made

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -11,9 +11,6 @@ export default class Slider extends Component {
     constructor(props) {
         super(props);
         this.propsToState = this.propsToState.bind(this);
-        this.DashSlider = props.tooltip
-            ? createSliderWithTooltip(ReactSlider)
-            : ReactSlider;
     }
 
     propsToState(newProps) {
@@ -40,6 +37,10 @@ export default class Slider extends Component {
         } = this.props;
         const value = this.state.value;
 
+        const DashSlider = tooltip
+            ? createSliderWithTooltip(ReactSlider)
+            : ReactSlider;
+
         return (
             <div
                 id={id}
@@ -49,7 +50,7 @@ export default class Slider extends Component {
                 className={className}
                 style={vertical ? {height: '100%'} : {}}
             >
-                <this.DashSlider
+                <DashSlider
                     onChange={value => {
                         if (updatemode === 'drag') {
                             setProps({value});

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -12,8 +12,8 @@ export default class Slider extends Component {
         super(props);
         this.propsToState = this.propsToState.bind(this);
         this.DashSlider = props.tooltip
-            ? createSliderWithTooltip(Range)
-            : Range;
+            ? createSliderWithTooltip(ReactSlider)
+            : ReactSlider;
     }
 
     propsToState(newProps) {

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -11,6 +11,9 @@ export default class Slider extends Component {
     constructor(props) {
         super(props);
         this.propsToState = this.propsToState.bind(this);
+        this.DashSlider = props.tooltip
+          ? createSliderWithTooltip(Range)
+          : Range;
     }
 
     propsToState(newProps) {
@@ -37,10 +40,6 @@ export default class Slider extends Component {
         } = this.props;
         const value = this.state.value;
 
-        const DashSlider = tooltip
-          ? createSliderWithTooltip(ReactSlider)
-          : ReactSlider;
-
         return (
             <div
                 id={id}
@@ -50,7 +49,7 @@ export default class Slider extends Component {
                 className={className}
                 style={vertical ? {height: '100%'} : {}}
             >
-                <DashSlider
+                <this.DashSlider
                     onChange={value => {
                         if (updatemode === 'drag') {
                             setProps({value});
@@ -139,24 +138,29 @@ Slider.propTypes = {
      */
     max: PropTypes.number,
 
-    /**
-     * Object that holds optional tooltip parameters
-     */
     tooltip: PropTypes.oneOfType([
-
-        // TODO: variations on PropTypes.exact
-
         /**
          * Determines whether tooltips should always be visible
+         * (as opposed to the default, visible on hover)
          */
         PropTypes.exact({
-            visible: PropTypes.oneOf(['visible', 'hover'])
+            visible: PropTypes.oneOf(['visible', 'hover']).isRequired
         }),
 
-        PropTypes.exact([
+        /**
+         * Determines the position of tooltips
+         * See https://github.com/react-component/tooltip#api
+         * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
+         * in reality appear to be on the top right of the handle
+         */
+        PropTypes.exact({
+            position: PropTypes.oneOf(['left','right','top','bottom', 'topLeft', 'topRight', 'bottomLeft', 'bottomRight']).isRequired
+        }),
+
+        PropTypes.exact({
             visible: PropTypes.oneOf(['visible', 'hover']),
-            position: PropTypes.oneOf(['top', 'hover'])
-        ])
+            position: PropTypes.oneOf(['left','right','top','bottom', 'topLeft', 'topRight', 'bottomLeft', 'bottomRight'])
+        })
     ]),
 
     /**

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -12,8 +12,8 @@ export default class Slider extends Component {
         super(props);
         this.propsToState = this.propsToState.bind(this);
         this.DashSlider = props.tooltip
-          ? createSliderWithTooltip(Range)
-          : Range;
+            ? createSliderWithTooltip(Range)
+            : Range;
     }
 
     propsToState(newProps) {
@@ -144,7 +144,7 @@ Slider.propTypes = {
          * (as opposed to the default, visible on hover)
          */
         PropTypes.exact({
-            visible: PropTypes.oneOf(['visible', 'hover']).isRequired
+            visible: PropTypes.bool.isRequired,
         }),
 
         /**
@@ -154,13 +154,31 @@ Slider.propTypes = {
          * in reality appear to be on the top right of the handle
          */
         PropTypes.exact({
-            position: PropTypes.oneOf(['left','right','top','bottom', 'topLeft', 'topRight', 'bottomLeft', 'bottomRight']).isRequired
+            position: PropTypes.oneOf([
+                'left',
+                'right',
+                'top',
+                'bottom',
+                'topLeft',
+                'topRight',
+                'bottomLeft',
+                'bottomRight',
+            ]).isRequired,
         }),
 
         PropTypes.exact({
             visible: PropTypes.oneOf(['visible', 'hover']),
-            position: PropTypes.oneOf(['left','right','top','bottom', 'topLeft', 'topRight', 'bottomLeft', 'bottomRight'])
-        })
+            position: PropTypes.oneOf([
+                'left',
+                'right',
+                'top',
+                'bottom',
+                'topLeft',
+                'topRight',
+                'bottomLeft',
+                'bottomRight',
+            ]),
+        }),
     ]),
 
     /**

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -140,18 +140,18 @@ Slider.propTypes = {
     max: PropTypes.number,
 
     tooltip: PropTypes.exact({
-       /**
-        * Determines whether tooltips should always be visible
-        * (as opposed to the default, visible on hover)
-        */
+        /**
+         * Determines whether tooltips should always be visible
+         * (as opposed to the default, visible on hover)
+         */
         visible: PropTypes.bool,
 
         /**
-        * Determines the position of tooltips
-        * See https://github.com/react-component/tooltip#api
-        * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
-        * in reality appear to be on the top right of the handle
-        */
+         * Determines the position of tooltips
+         * See https://github.com/react-component/tooltip#api
+         * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
+         * in reality appear to be on the top right of the handle
+         */
         position: PropTypes.oneOf([
             'left',
             'right',

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -11,6 +11,9 @@ export default class Slider extends Component {
     constructor(props) {
         super(props);
         this.propsToState = this.propsToState.bind(this);
+        this.DashSlider = props.tooltip
+            ? createSliderWithTooltip(ReactSlider)
+            : ReactSlider;
     }
 
     propsToState(newProps) {
@@ -18,6 +21,11 @@ export default class Slider extends Component {
     }
 
     componentWillReceiveProps(newProps) {
+        if (newProps.tooltip !== this.props.tooltip) {
+            this.DashSlider = newProps.tooltip
+                ? createSliderWithTooltip(ReactSlider)
+                : ReactSlider;
+        }
         this.propsToState(newProps);
     }
 
@@ -37,10 +45,6 @@ export default class Slider extends Component {
         } = this.props;
         const value = this.state.value;
 
-        const DashSlider = tooltip
-            ? createSliderWithTooltip(ReactSlider)
-            : ReactSlider;
-
         let tipProps;
         if (tooltip && tooltip.always_visible) {
             /**
@@ -49,8 +53,8 @@ export default class Slider extends Component {
              * assigns the new (renamed) key to the old key and deletes the old key
              */
             tipProps = Object.assign(tooltip, {
-                visible: tooltip.always_visible
-            })
+                visible: tooltip.always_visible,
+            });
             delete tipProps.always_visible;
         } else {
             tipProps = tooltip;
@@ -65,7 +69,7 @@ export default class Slider extends Component {
                 className={className}
                 style={vertical ? {height: '100%'} : {}}
             >
-                <DashSlider
+                <this.DashSlider
                     onChange={value => {
                         if (updatemode === 'drag') {
                             setProps({value});

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -41,6 +41,21 @@ export default class Slider extends Component {
             ? createSliderWithTooltip(ReactSlider)
             : ReactSlider;
 
+        let tipProps;
+        if (tooltip && tooltip.always_visible) {
+            /**
+             * clone `tooltip` but with renamed key `always_visible` -> `visible`
+             * the rc-tooltip API uses `visible`, but `always_visible is more semantic
+             * assigns the new (renamed) key to the old key and deletes the old key
+             */
+            tipProps = Object.assign(tooltip, {
+                visible: tooltip.always_visible
+            })
+            delete tipProps.always_visible;
+        } else {
+            tipProps = tooltip;
+        }
+
         return (
             <div
                 id={id}
@@ -144,15 +159,15 @@ Slider.propTypes = {
          * Determines whether tooltips should always be visible
          * (as opposed to the default, visible on hover)
          */
-        visible: PropTypes.bool,
+        always_visible: PropTypes.bool,
 
         /**
-         * Determines the position of tooltips
+         * Determines the placement of tooltips
          * See https://github.com/react-component/tooltip#api
          * top/bottom{*} sets the _origin_ of the tooltip, so e.g. `topLeft` will
          * in reality appear to be on the top right of the handle
          */
-        position: PropTypes.oneOf([
+        placement: PropTypes.oneOf([
             'left',
             'right',
             'top',


### PR DESCRIPTION
This PR enables tooltips over `dcc.Slider` and `dcc.RangeSlider` handles, either on hover or always. Motivated by a customer request via @cldougl, but it's been [desired](https://stackoverflow.com/questions/54229804/how-to-add-a-label-over-slider-selector) in our open-source community as well. 

Adds a new property `tooltip` that passes in parameters from `tipProps`, an object native to the `rc-slider` `createSliderWithTooltip` API. `tipProps` isn't very well documented but AFAIK it essentially mirrors the [rc-tooltip API](https://github.com/react-component/tooltip#api). See example of `tipProps` usage in React [here](https://codesandbox.io/s/zn908z99yx).