### PR TITLE
externalize prop-types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ jobs:
             - run:
                 name: Install dependencies (dash)
                 command: |
-                    git clone --depth 1 git@github.com:plotly/dash.git dash-main
-                    git clone --depth 1 git@github.com:plotly/dash-html-components.git
+                    git clone --depth 1  -b prop-types-dev git@github.com:plotly/dash.git dash-main
+                    git clone --depth 1  -b prop-types-dev git@github.com:plotly/dash-html-components.git
                     . venv/bin/activate
                     pip install -e ./dash-main --quiet
                     cd dash-html-components && npm install --ignore-scripts && npm run build && pip install -e . && cd ..

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = (env, argv) => {
         react: 'React',
         'react-dom': 'ReactDOM',
         'plotly.js': 'Plotly',
+        'prop-types': 'PropTypes'
     });
 
     return {


### PR DESCRIPTION
Externalize prop-types so that `dash-renderer` can be responsible for providing the right version to all components.