### PR TITLE
Fix tab disabled issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ability to add tooltips to `Slider` and `RangeSlider`, which can be visible always or on hover. Tooltips also take a position argument. [#564](https://github.com/plotly/dash-core-components/pull/564)
 
 ### Fixed
-- Fixed `min_date_allowed` and `max_date_allowed` bug in `DatePickerRange` [#551]https://github.com/plotly/dash-core-components/issues/551)
+- Fixed `min_date_allowed` and `max_date_allowed` bug in `DatePickerRange` [#551](https://github.com/plotly/dash-core-components/issues/551)
 - Fixed unwanted `resize()` calls on unmounted `Graph`s [#534](https://github.com/plotly/dash-core-components/issues/534)
+- Fixed `tab--disabled` CSS class issue in `Tab` component with custom styling
 
 ### Changed
 - Changed `dcc.Checklist` prop `values` to `value`, to match all the other input components [#558](https://github.com/plotly/dash-core-components/pull/558). Also improved prop types for `Dropdown` and `RadioItems` `value` props to consistently accept both strings and numbers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed `min_date_allowed` and `max_date_allowed` bug in `DatePickerRange` [#551](https://github.com/plotly/dash-core-components/issues/551)
 - Fixed unwanted `resize()` calls on unmounted `Graph`s [#534](https://github.com/plotly/dash-core-components/issues/534)
-- Fixed `tab--disabled` CSS class issue in `Tab` component with custom styling
+- Fixed `tab--disabled` CSS class issue in `Tab` component with custom styling [#568](https://github.com/plotly/dash-core-components/pull/568)
 
 ### Changed
 - Changed `dcc.Checklist` prop `values` to `value`, to match all the other input components [#558](https://github.com/plotly/dash-core-components/pull/558). Also improved prop types for `Dropdown` and `RadioItems` `value` props to consistently accept both strings and numbers.

--- a/src/components/Tabs.react.js
+++ b/src/components/Tabs.react.js
@@ -33,7 +33,7 @@ const EnhancedTab = ({
     }
     let tabClassName = `tab ${className || ''}`;
     if (disabled) {
-        tabClassName += `tab--disabled ${disabled_className || ''}`;
+        tabClassName += ` tab--disabled ${disabled_className || ''}`;
     }
     if (selected) {
         tabClassName += ` tab--selected ${selectedClassName || ''}`;

--- a/test/assets/testing.css
+++ b/test/assets/testing.css
@@ -2,3 +2,7 @@
     width: 420px;
     border-color: hotpink;
 }
+
+.test-custom-tab {
+    font-weight: bold;
+}

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -2406,6 +2406,26 @@ class Tests(IntegrationTests):
     #                    )
     #                )
     #
+    def test_disabled_tab(self):
+        app = dash.Dash(__name__)
+        app.layout = html.Div([
+            html.H1("Dash Tabs component with disabled tab demo"),
+            dcc.Tabs(id="tabs-example", value='tab-2', children=[
+                dcc.Tab(label="Disabled Tab", value="tab-1", id="tab-1", className="test-custom-tab", disabled=True),
+                dcc.Tab(label="Active Tab", value="tab-2", id="tab-2", className="test-custom-tab"),
+            ]),
+            html.Div(id="tabs-content-example"),
+        ])
+        self.startServer(app=app)
+
+        WebDriverWait(self.driver, TIMEOUT).until(
+            EC.element_to_be_clickable((By.ID, "tab-2"))
+        )
+
+        WebDriverWait(self.driver, TIMEOUT).until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, ".tab--disabled"))
+        )
+
     def test_unmounted_graph_resize(self):
         app = dash.Dash(__name__)
 


### PR DESCRIPTION
Fix an issue occurring in the Tab component when disabled and styled with custom CSS classes.
The `tab--disabled` CSS class was appended to the component className without an initial space and was concatenated to the last custom CSS class if provided, consequently breaking the styling.

I had also a simple test to check if the disabled Tab component is findable by the `tab--disabled` CSS class.

It's my first PR, let me know if it's okay or if I have to do something more.