### PR TITLE
603 graph cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+### Fixed
+- Fixed problems with `Graph` components leaking events and being recreated multiple times if declared with no ID [#604](https://github.com/plotly/dash-core-components/pull/604)
+
 ## [1.1.1] - 2019-08-06
 - Upgraded plotly.js to 1.49.1 [#595](https://github.com/plotly/dash-core-components/issues/595)
 - Patch release [1.49.1](https://github.com/plotly/plotly.js/releases/tag/v1.49.1)

--- a/src/components/Graph.react.js
+++ b/src/components/Graph.react.js
@@ -212,8 +212,9 @@ class PlotlyGraph extends Component {
     }
 
     componentWillUnmount() {
-        if (this.eventEmitter) {
-            this.eventEmitter.removeAllListeners();
+        const gd = document.getElementById(this.props.id);
+        if (gd && gd.removeAllListeners) {
+            gd.removeAllListeners();
         }
         window.removeEventListener('resize', this.graphResize);
     }

--- a/src/components/Graph.react.js
+++ b/src/components/Graph.react.js
@@ -106,7 +106,10 @@ class PlotlyGraph extends Component {
 
             // in case we've made a new DOM element, transfer events
             if(this._hasPlotted && gd !== this._prevGd) {
-                this._prevGd.removeAllListeners();
+                if(this._prevGd && this._prevGd.removeAllListeners) {
+                    this._prevGd.removeAllListeners();
+                    Plotly.purge(this._prevGd);
+                }
                 this._hasPlotted = false;
             }
 

--- a/tests/integration/graph/test_graph_purge.py
+++ b/tests/integration/graph/test_graph_purge.py
@@ -1,0 +1,53 @@
+import time
+
+from selenium.webdriver.common.keys import Keys
+
+import dash
+from dash.dependencies import Input, Output
+import dash_core_components as dcc
+import dash_html_components as html
+
+
+def test_grgp001_clean_purge(dash_duo):
+    app = dash.Dash(__name__)
+
+    app.layout = html.Div([
+        html.Button("toggle children", id="tog"),
+        html.Div(id="out")
+    ])
+
+    @app.callback(
+        Output("out", "children"),
+        [Input("tog", "n_clicks")]
+    )
+    def show_output(num):
+        if (num or 0) % 2:
+            return dcc.Graph(figure={
+                "data": [{
+                    "type": "scatter3d", "x": [1, 2], "y": [3, 4], "z": [5, 6]
+                }],
+                "layout": {"title": {"text": "A graph!"}}
+            })
+        else:
+            return "No graphs here!"
+
+    dash_duo.start_server(app)
+
+    dash_duo.wait_for_text_to_equal("#out", "No graphs here!")
+
+    tog = dash_duo.find_element("#tog")
+    tog.click()
+    dash_duo.wait_for_text_to_equal("#out .gtitle", "A graph!")
+
+    tog.click()
+    dash_duo.wait_for_text_to_equal("#out", "No graphs here!")
+
+    dash_duo.find_element('body').send_keys(Keys.CONTROL)
+
+    # the error with CONTROL was happening in an animation frame loop
+    # wait a little to ensure it has fired
+    time.sleep(0.5)
+    assert not dash_duo.get_logs()
+
+    tog.click()
+    dash_duo.wait_for_text_to_equal("#out .gtitle", "A graph!")


### PR DESCRIPTION
Fixes #603 

Cleans up properly when a `Graph` is unmounted, and stops creating random IDs when no ID is provided - instead using a `ref` to connect directly to the DOM element.