### PR TITLE
CI branch conditional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           command: |
             . venv/bin/activate && pip install --upgrade -e . --quiet && mkdir packages
             if [ $CIRCLE_BRANCH = "master" ]; then
-              echo "Clone from ci_exp branch"
+              echo "Clone from master branch"
               git clone -b master --depth 1 https://github.com/plotly/dash.git dash-main
               git clone -b master --depth 1 https://github.com/plotly/dash-html-components.git
             else


### PR DESCRIPTION
With our move from `master` to `dev` as the default branch for the repos, make sure to distinguish the `master` build to use `master` instead of the default branch - useful for final validation / release.