### PR TITLE
feat: disable cookie/localstorage access under restricted sandboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- [#729](https://github.com/plotly/dash-core-components/pull/729) Handle case where dcc fails to load when used inside an iframe with a sandbox attribute that only has allow-scripts
+
 ## [1.7.1] - 2020-01-15 (JS-only)
 ### Fixed
 - [#734](https://github.com/plotly/dash-core-components/pull/734) Fix JS-facing release bug where `Plotly.js` was listed in `devDependencies` instead of `dependencies`

--- a/src/components/Store.react.js
+++ b/src/components/Store.react.js
@@ -112,9 +112,6 @@ class WebStore {
     }
 }
 
-const _localStore = new WebStore(window.localStorage);
-const _sessionStore = new WebStore(window.sessionStorage);
-
 /**
  * Easily keep data on the client side with this component.
  * The data is not inserted in the DOM.
@@ -126,9 +123,9 @@ export default class Store extends React.Component {
         super(props);
 
         if (props.storage_type === 'local') {
-            this._backstore = _localStore;
+            this._backstore = new WebStore(window.localStorage);
         } else if (props.storage_type === 'session') {
-            this._backstore = _sessionStore;
+            this._backstore = new WebStore(window.sessionStorage);
         } else if (props.storage_type === 'memory') {
             this._backstore = new MemStore();
         }


### PR DESCRIPTION
When dash is embedded into an iframe with a sandbox attribute that only has allow-scripts, cookie/localstorage access is disabled and dash-core-components fails to load. As such, we need to restrict our cookie/localstorage usage by disabling functionality.

This patch removes the disabled functionality in a graceful manner, allowing dash-core-components to load in very restricted iframes.