### PR TITLE
full propTypes for ControlledPlotlyGraph to avoid weird React warning

### DIFF
--- a/src/components/Graph.react.js
+++ b/src/components/Graph.react.js
@@ -115,8 +115,6 @@ const ControlledPlotlyGraph = memo(props => {
     );
 });
 
-ControlledPlotlyGraph.propTypes = PropTypes.any;
-
 PlotlyGraph.propTypes = {
     ...privatePropTypes,
 
@@ -514,6 +512,8 @@ PlotlyGraph.propTypes = {
         component_name: PropTypes.string,
     }),
 };
+
+ControlledPlotlyGraph.propTypes = PlotlyGraph.propTypes;
 
 PlotlyGraph.defaultProps = {
     ...privateDefaultProps,


### PR DESCRIPTION
@Marc-Andre-Rivet this appears to remove the warning I describe in https://github.com/plotly/dash-core-components/pull/706/files#r377687277 when showing graphs with debug mode

```
The prop `isRequired` is marked as required in `<<anonymous>>`,
but its value is `undefined`
```