### PR TITLE
Add R examples to dashCoreComponents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
   lint-unit-27:
     <<: *lint-unit
     docker:
-      - image: circleci/python:2.7-stretch-node-browsers
+      - image: circleci/python:2.7.16-stretch-node-browsers
         environment:
           PYTHON_VERSION: py27
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
   lint-unit-27:
     <<: *lint-unit
     docker:
-      - image: circleci/python:2.7.16-stretch-node-browsers
+      - image: circleci/python:2.7-stretch-node-browsers
         environment:
           PYTHON_VERSION: py27
 

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -35,6 +35,7 @@ r_examples:
             library(dash)
             library(dashHtmlComponents)
             library(dashCoreComponents)
+            library(plotly)
 
             app <- Dash$new()
 

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -651,6 +651,7 @@ r_examples:
             library(dash)
             library(dashCoreComponents)
             library(plotly)
+            app <- Dash$new()
             
             year <- c(1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003,
               2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012)

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -200,9 +200,7 @@ r_examples:
             library(dashCoreComponents)
             library(dashHtmlComponents)
             library(dash)
-            
             app <- Dash$new()
-            
             app$layout(htmlDiv(list(
               # The memory store reverts to the default on every page refresh
               dccStore(id='memory'),
@@ -215,7 +213,7 @@ r_examples:
               dccStore(id='session', storage_type='session'),
               htmlTable(list(
                 htmlThead(list(
-                  htmlTr(htmlTh('Click to store in:', colSpan="3")),
+                  htmlTr(htmlTh('Click to store in:', colSpan='3')),
                   htmlTr(list(
                     htmlTh(htmlButton('memory', id='memory-button')),
                     htmlTh(htmlButton('localStorage', id='local-button')),
@@ -236,75 +234,49 @@ r_examples:
                 ))
               ))
             )))
-
-            storeData <- function(n_clicks, values) {
-                if (is.null(n_clicks)) {
-                  return()
+            for (i in c('memory', 'local', 'session')) {
+              app$callback(
+                output(id = i, property = 'data'),
+                params = list(
+                  input(id = sprintf('%s-button', i), property = 'n_clicks'),
+                  state(id = i, property = 'data')
+                ),
+                function(n_clicks, data){
+                  if(is.null(n_clicks)){
+                    return()
+                  }
+                  
+                  if(is.null(data[[1]])){
+                    data = list('clicks' = 0)
+                  } else{
+                    data = data
+                  }  
+                  data['clicks'] = data$clicks + 1
+                  return(data)
                 }
-            
-                if (is.null(values[[1]]))
-                  values = list('clicks' = 0)
-                else
-                  values = values
-                
-                values['clicks'] = values$clicks + 1
-                return(values)
+              )
             }
-            
-            returnStoreData <- function(ts, values) {
-                if (is.null(ts))
-                  return()
-                if (is.null(values[[1]]))
-                  values = list()
-                else
-                  values = values
-                
-                return(values[[1]])
+            for (i in c('memory', 'local', 'session')) {
+              app$callback(
+                output(id = sprintf('%s-clicks', i), property = 'children'),
+                params = list(
+                  input(id = i, property = 'modified_timestamp'),
+                  state(id = i, property = 'data')
+                ),
+                function(ts, data){
+                  if(is.null(ts)){
+                    return()
+                  }
+                  if(is.null(data[[1]])){
+                    data = list()
+                  } else{
+                    data = data
+                  }  
+                  return(data$clicks[[1]])
+                }
+              )
             }
-            
-            app$callback(
-              output = list(id = 'memory', property = 'data'),
-              params = list(input(id = 'memory-button', property = 'n_clicks'),
-                            state(id = 'memory', property = 'data')),
-              storeData
-            )
-            
-            app$callback(
-              output = list(id = 'memory-clicks', property = 'children'),
-              params = list(input(id = 'memory', property = 'modified_timestamp'),
-                            state(id = 'memory', property = 'data')),
-              returnStoreData
-            )
-            
-            app$callback(
-              output = list(id = 'local', property = 'data'),
-              params = list(input(id = 'local-button', property = 'n_clicks'),
-                            state(id = 'local', property = 'data')),
-              storeData
-            )
-            
-            app$callback(
-              output = list(id = 'local-clicks', property = 'children'),
-              params = list(input(id = 'local', property = 'modified_timestamp'),
-                            state(id = 'local', property = 'data')),
-              returnStoreData
-            )
-            
-            app$callback(
-              output = list(id = 'session', property = 'data'),
-              params = list(input(id = 'session-button', property = 'n_clicks'),
-                            state(id = 'session', property = 'data')),
-              storeData
-            )
-            
-            app$callback(
-              output = list(id = 'session-clicks', property = 'children'),
-              params = list(input(id = 'session', property = 'modified_timestamp'),
-                            state(id = 'session', property = 'data')),
-              returnStoreData
-            )
-            
-            app$run_server()      
+            app$run_server()
     - name: dccConfirmDialogProvider
       dontrun: TRUE 
       code: | 

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -21,7 +21,7 @@ r_examples:
                 id = "checklist-input",
                 options=list(
                   list("label" = "New York City", "value" = "NYC"),
-                  list("label" = "Montréal", "value" = "MTL"),
+                  list("label" = "Montreal", "value" = "MTL"),
                   list("label" = "San Francisco", "value" = "SF")
                 ),
                 value=list("MTL", "SF")
@@ -731,7 +731,7 @@ r_examples:
                 dccRadioItems(
                   options=list(
                     list("label" = "New York City", "value" = "NYC"),
-                    list("label" = "Montréal", "value" = "MTL"),
+                    list("label" = "Montreal", "value" = "MTL"),
                     list("label" = "San Francisco", "value" = "SF")
                   ),
                   value = "MTL"

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -635,10 +635,13 @@ r_examples:
                             state(id = 'upload-image', property = 'filename'),
                             state(id = 'upload-image', property = 'last_modified')),
               function(list_of_contents, list_of_names, list_of_dates){
-                if (!is.null(list_of_contents) && !is.null(list_of_names) && !is.null(list_of_dates)) {
+                if (!is.null(list_of_contents) && !is.null(list_of_names) && !is.null(list_of_dates[[1)) {
                   children = lapply(1:length(list_of_contents), function(x){
                     parse_content(list_of_contents[[x]], list_of_names[[x]], list_of_dates[[x]])
                   })
+                }
+                else {
+                  children = "Upload a file to see the raw data."
                 }
                 return(children)
               }

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -6,3 +6,782 @@ pkg_help_description: >-
     is on GitHub: plotly/dash-core-components.
 pkg_help_title: >-
     Core Interactive UI Components for Dash 
+r_examples:
+    - name: dccChecklist
+      dontrun: TRUE 
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              dccChecklist(
+                id = "checklist-input",
+                options=list(
+                  list("label" = "New York City", "value" = "NYC"),
+                  list("label" = "Montréal", "value" = "MTL"),
+                  list("label" = "San Francisco", "value" = "SF")
+                ),
+                value=list("MTL", "SF")
+              )
+            )
+
+            app$run_server()
+    - name: dccInterval
+      dontrun: TRUE 
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(list(
+                htmlH2('3 Second Updates'),
+                dccInterval(id = '3s-interval', 
+                            interval= 3*1000, 
+                            n_intervals = 0),
+                htmlDiv(list(
+                    dccGraph(id = 'live-graph')
+                  )
+                 )
+                )
+              )
+            )
+            
+            app$callback(
+              output = list(
+                output('live-graph', 'figure')
+              ),
+              params = list(
+                input('3s-interval', 'n_intervals')
+              ),
+              
+              update_graph <- function(n_intervals) {
+                df <- data.frame(
+                  'time' = c(1:8),
+                  'value' = sample(1:8, 8),
+                  'value-2' = sample(1:8, 8)
+                )
+            
+                bar <- animation_opts(plot_ly(
+                  data = df, x=~time, y=~value, type = "bar"
+                  ),
+                  1000, easing = "cubic-in-out"
+                )
+                
+                return(list(bar))
+              }
+            )
+            
+            app$run_server()
+    - name: dccSlider
+      dontrun: TRUE 
+      code: |
+            library(dash)
+            library(dashCoreComponents)
+            library(dashHtmlComponents)
+
+            app <- Dash$new()
+
+            app$layout(
+              htmlDiv(
+                list(
+                  dccSlider(
+                    id = "slider-input",
+                    min = -5,
+                    max = 10,
+                    step = 0.5,
+                    value = -3,
+                  ),
+                  htmlDiv(
+                    id = "slider-output",
+                    children = "Make a selection on the slider to see the value appear here."
+                  )
+                )
+              )
+            )
+            
+            app$callback(
+              output("slider-output", "children"),
+              list(input("slider-input", "value")),
+              function(value) {
+                return(sprintf("You have chosen %s on the slider above.", value))
+              }
+            )
+
+            app$run_server()
+    - name: dccConfirmDialog
+      dontrun: TRUE 
+      code: |
+            library(dash)
+            library(dashCoreComponents)
+            library(dashHtmlComponents)
+
+            app <- Dash$new()
+            
+            app$layout(
+              htmlDiv(
+                list(
+                  dccConfirmDialog(
+                    id='confirm',
+                    message='Danger danger! Are you sure you want to continue?'
+                  ),
+            
+                  dccDropdown(
+                    options=lapply(list('Safe', 'Danger!!'),function(x){list('label'= x, 'value'= x)}),
+                    id='dropdown'
+                  ),
+                  htmlDiv(id='output-confirm1')
+                )
+              )
+            )
+            
+            app$callback(
+              output = list(id = 'confirm', property = 'displayed'),
+              params=list(input(id = 'dropdown', property = 'value')),
+              function(value){
+                if(value == 'Danger!!'){
+                  return(TRUE)}
+                else{
+                  return(FALSE)}
+              })
+            
+            
+            app$callback(
+              output = list(id = 'output-confirm1', property = 'children'),
+              params=list(input(id = 'confirm', property = 'submit_n_clicks')),
+              function(n_clicks, value) {
+                if(length(n_clicks) == FALSE){
+                  sprintf('It wasnt easy but we did it %s', str(n_clicks))
+                }
+              })
+            
+            app$run_server()
+    - name: dccLink
+      dontrun: TRUE 
+      code: |            
+            library(dash)
+            library(dashCoreComponents)
+            library(dashHtmlComponents)
+        
+            app <- Dash$new()
+        
+            app$layout(htmlDiv(list(
+                      # represents the URL bar, doesn't render anything
+                      dccLocation(id = 'url', refresh=FALSE),
+                      dccLink('Navigate to "/"', href='/'),
+                      htmlBr(),
+                      dccLink('Navigate to "/page-2"', href='/page-2'),
+        
+                      # content will be rendered in this element
+                      htmlDiv(id='page-content')
+                    )
+                )
+            )
+        
+            app$callback(output=list(id='page-content', property='children'),
+                         params=list(
+                      input(id='url', property='pathname')),
+                      function(pathname)
+                      {
+                      sprintf('You are on page %s', pathname)
+                      }
+            )
+        
+            app$run_server()      
+    - name: dccStore
+      dontrun: TRUE 
+      code: | 
+            library(dashCoreComponents)
+            library(dashHtmlComponents)
+            library(dash)
+            
+            app <- Dash$new()
+            
+            app$layout(htmlDiv(list(
+              # The memory store reverts to the default on every page refresh
+              dccStore(id='memory'),
+              # The local store will take the initial data
+              # only the first time the page is loaded
+              # and keep it until it is cleared.
+              dccStore(id='local', storage_type='local'),
+              # Same as the local store but will lose the data
+              # when the browser/tab closes.
+              dccStore(id='session', storage_type='session'),
+              htmlTable(list(
+                htmlThead(list(
+                  htmlTr(htmlTh('Click to store in:', colSpan="3")),
+                  htmlTr(list(
+                    htmlTh(htmlButton('memory', id='memory-button')),
+                    htmlTh(htmlButton('localStorage', id='local-button')),
+                    htmlTh(htmlButton('sessionStorage', id='session-button'))
+                  )),
+                  htmlTr(list(
+                    htmlTh('Memory clicks'),
+                    htmlTh('Local clicks'),
+                    htmlTh('Session clicks')
+                  ))
+                )),
+                htmlTbody(list(
+                  htmlTr(list(
+                    htmlTd(0, id='memory-clicks'),
+                    htmlTd(0, id='local-clicks'),
+                    htmlTd(0, id='session-clicks')
+                  ))
+                ))
+              ))
+            )))
+
+            storeData <- function(n_clicks, values) {
+                if (is.null(n_clicks)) {
+                  return()
+                }
+            
+                if (is.null(values[[1]]))
+                  values = list('clicks' = 0)
+                else
+                  values = values
+                
+                values['clicks'] = values$clicks + 1
+                return(values)
+            }
+            
+            returnStoreData <- function(ts, values) {
+                if (is.null(ts))
+                  return()
+                if (is.null(values[[1]]))
+                  values = list()
+                else
+                  values = values
+                
+                return(values[[1]])
+            }
+            
+            app$callback(
+              output = list(id = 'memory', property = 'data'),
+              params = list(input(id = 'memory-button', property = 'n_clicks'),
+                            state(id = 'memory', property = 'data')),
+              storeData
+            )
+            
+            app$callback(
+              output = list(id = 'memory-clicks', property = 'children'),
+              params = list(input(id = 'memory', property = 'modified_timestamp'),
+                            state(id = 'memory', property = 'data')),
+              returnStoreData
+            )
+            
+            app$callback(
+              output = list(id = 'local', property = 'data'),
+              params = list(input(id = 'local-button', property = 'n_clicks'),
+                            state(id = 'local', property = 'data')),
+              storeData
+            )
+            
+            app$callback(
+              output = list(id = 'local-clicks', property = 'children'),
+              params = list(input(id = 'local', property = 'modified_timestamp'),
+                            state(id = 'local', property = 'data')),
+              returnStoreData
+            )
+            
+            app$callback(
+              output = list(id = 'session', property = 'data'),
+              params = list(input(id = 'session-button', property = 'n_clicks'),
+                            state(id = 'session', property = 'data')),
+              storeData
+            )
+            
+            app$callback(
+              output = list(id = 'session-clicks', property = 'children'),
+              params = list(input(id = 'session', property = 'modified_timestamp'),
+                            state(id = 'session', property = 'data')),
+              returnStoreData
+            )
+            
+            app$run_server()      
+    - name: dccConfirmDialogProvider
+      dontrun: TRUE 
+      code: | 
+            library(dash)
+            library(dashCoreComponents)
+            library(dashHtmlComponents)
+
+            app <- Dash$new()
+            
+            app$layout(htmlDiv(list(
+              dccConfirmDialogProvider(
+                children=htmlButton(
+                  'Click Me',
+                  n_clicks = 0
+                ),
+                id='danger-danger-provider',
+                message='Danger danger! Are you sure you want to continue?',
+                submit_n_clicks=NULL
+              ),
+              htmlDiv(id='output-provider',
+                      children='Click the button to submit')
+            )))
+            
+            app$callback(
+              output = list(id = 'output-provider', property = 'children'),
+              params=list(input(id = 'danger-danger-provider', property = 'submit_n_clicks')),
+              function(submit_n_clicks){
+                if (is.null(unlist(submit_n_clicks))){
+                  return('')
+                } else{
+                  sprintf('That was a dangerous choice!
+                          Submitted %s times.', submit_n_clicks)
+                }
+                }
+            
+            )
+            
+            app$run_server()
+    - name: dccLoading
+      dontrun: TRUE 
+      code: | 
+            library(dash)
+            library(dashCoreComponents)
+            library(dashHtmlComponents)
+            
+            app <- Dash$new()
+            
+            app$layout(htmlDiv(
+              children=list(
+                htmlH3("Edit text input to see loading state"),
+                dccInput(id="input-1", value='Input triggers local spinner'),
+                dccLoading(id="loading-1", children=list(htmlDiv(id="loading-output-1")), type="default"),
+                htmlDiv(
+                  list(
+                    dccInput(id="input-2", value='Input triggers nested spinner'),
+                    dccLoading(
+                      id="loading-2",
+                      children=list(htmlDiv(list(htmlDiv(id="loading-output-2")))),
+                      type="circle"
+                    )
+                  )
+                )
+              )
+            ))
+            
+            app$callback(
+              output = list(id='loading-output-1', property = 'children'),
+              params = list(input(id = 'input-1', property = 'value')),
+              function(value){
+                Sys.sleep(1)
+                return(value)
+              }
+            )
+            
+            app$callback(
+              output = list(id='loading-output-2', property = 'children'),
+              params = list(input(id = 'input-2', property = 'value')),
+              function(value){
+                Sys.sleep(1)
+                return(value)
+              }
+            )
+            
+            app$run_server()            
+    - name: dccTab
+      dontrun: TRUE 
+      code: | 
+            library(dash)
+            library(dashCoreComponents)
+            library(dashHtmlComponents)
+            
+            app <- Dash$new()
+            
+            app$layout(htmlDiv(list(
+              dccTabs(id="tabs", value='tab-1', children=list(
+                dccTab(label='Tab one', value='tab-1'),
+                dccTab(label='Tab two', value='tab-2')
+                )
+              ),
+              htmlDiv(id='tabs-content')
+              )
+              )
+            )
+            
+            app$callback(output('tabs-content', 'children'),
+                params = list(input('tabs', 'value')),
+            function(tab){
+              if(tab == 'tab-1'){
+              return(htmlDiv(list(
+                htmlH3('Tab content 1')
+                )))}
+              else if(tab == 'tab-2'){
+              return(htmlDiv(list(
+                htmlH3('Tab content 2')
+                )))}
+              }
+            )
+
+            app$run_server()      
+    - name: dccDatePickerRange
+      dontrun: TRUE 
+      code: |
+            library(dash)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+            
+            app$layout(
+              dccDatePickerRange(
+                id = "date-picker-range",
+                start_date = as.Date("1997/5/10"),
+                end_date_placeholder_text="Select a date!"
+              )
+            )
+            
+            app$run_server()
+    - name: dccLocation
+      dontrun: TRUE 
+      code: | 
+            library(dash)
+            library(dashCoreComponents)
+            library(dashHtmlComponents)
+        
+            app <- Dash$new()
+        
+            app$layout(htmlDiv(list(
+                      # represents the URL bar, doesn't render anything
+                      dccLocation(id = 'url', refresh=FALSE),
+                      dccLink('Navigate to "/"', href='/'),
+                      htmlBr(),
+                      dccLink('Navigate to "/page-2"', href='/page-2'),
+        
+                      # content will be rendered in this element
+                      htmlDiv(id='page-content')
+                    )
+                )
+            )
+        
+            app$callback(output=list(id='page-content', property='children'),
+                         params=list(
+                      input(id='url', property='pathname')),
+                      function(pathname)
+                      {
+                      sprintf('You are on page %s', pathname)
+                      }
+            )
+        
+            app$run_server()
+    - name: dccTabs
+      dontrun: TRUE 
+      code: | 
+            library(dash)
+            library(dashCoreComponents)
+            library(dashHtmlComponents)
+            
+            app <- Dash$new()
+            
+            app$layout(htmlDiv(list(
+              dccTabs(id="tabs", value='tab-1', children=list(
+                dccTab(label='Tab one', value='tab-1'),
+                dccTab(label='Tab two', value='tab-2')
+                )
+              ),
+              htmlDiv(id='tabs-content')
+              )
+              )
+            )
+            
+            app$callback(output('tabs-content', 'children'),
+                params = list(input('tabs', 'value')),
+            function(tab){
+              if(tab == 'tab-1'){
+              return(htmlDiv(list(
+                htmlH3('Tab content 1')
+                )))}
+              else if(tab == 'tab-2'){
+              return(htmlDiv(list(
+                htmlH3('Tab content 2')
+                )))}
+              }
+            )
+
+            app$run_server()
+    - name: dccDatePickerSingle
+      dontrun: TRUE 
+      code: | 
+            library(dash)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+            
+            app$layout(
+              dccDatePickerSingle(
+                id = "date-picker-single",
+                date = as.Date("1997/5/10")
+              )
+            )
+            
+            app$run_server()      
+    - name: dccLogoutButton
+      dontrun: TRUE 
+      code: |
+            library(dash)
+            library(dashCoreComponents)
+            
+            app <- Dash$new()
+            
+            app$layout(
+              dccLogoutButton(logout_url='/custom-auth/logout')
+            )
+            
+            app$run_server()
+    - name: dccTextarea
+      dontrun: TRUE 
+      code: |
+            library(dash)
+            library(dashCoreComponents)
+            
+            app <- Dash$new()
+            
+            app$layout(
+              htmlDiv(
+                dccTextarea(
+                  placeholder = "Enter a value...",
+                  value = "This is a TextArea component",
+                  style = list("width" = "100%")
+                )
+              )
+            )
+            
+            app$run_server()
+    - name: dccDropdown
+      dontrun: TRUE 
+      code: |       
+            library(dash)
+            library(dashCoreComponents)
+            
+            app <- Dash$new()
+            
+            app$layout(
+              htmlDiv(
+                dccDropdown(
+                  options=list(
+                    list(label = "New York City", value = "NYC"),
+                    list(label = "Montreal", value = "MTL"),
+                    list(label = "San Francisco", value = "SF")
+                  ),
+                  value="MTL"
+                )
+              )
+            )
+            
+            app$run_server()
+    - name: dccMarkdown
+      dontrun: TRUE 
+      code: |
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+
+            app <- Dash$new()
+
+            app$title("dccMarkdown Syntax Highlighting Demo")
+
+            # dccMarkdown leverages Highlight.js, which allows
+            # app developers to specify the language inline
+            # and highlight its syntax properly:
+            app$layout(
+              htmlDiv(
+                list(
+                  htmlDiv(htmlH2("Syntax markdown demo:")),
+                  dccMarkdown(children = "
+                  ```r
+                  library(dash)
+                  library(dashHtmlComponents)
+                  
+                  app <- Dash$new()
+                  app$layout(htmlDiv('Dash app code wrapped within an app'))
+                  app$run_server()
+                  ```")
+                )
+              )
+            )
+            
+            app$run_server()
+    - name: dccUpload
+      dontrun: TRUE 
+      code: |
+            library(dash)
+            library(dashCoreComponents)
+            library(dashHtmlComponents)
+            library(jsonlite)
+            
+            app <- Dash$new()
+            
+            app$layout(htmlDiv(list(
+              dccUpload(
+                id='upload-image',
+                children=htmlDiv(list(
+                  'Drag and Drop or ',
+                  htmlA('Select Files')
+                )),
+                style=list(
+                  'width'= '100%',
+                  'height'= '60px',
+                  'lineHeight'= '60px',
+                  'borderWidth'= '1px',
+                  'borderStyle'= 'dashed',
+                  'borderRadius'= '5px',
+                  'textAlign'= 'center',
+                  'margin'= '10px'
+                ),
+                # Allow multiple files to be uploaded
+                multiple=TRUE
+              ),
+              htmlDiv(id='output-image-upload')
+            )))
+            
+            parse_content = function(contents, filename, date) {
+              return(htmlDiv(list(
+                htmlH5(filename),
+                htmlH6(as.POSIXct(date, origin="1970-01-01")),
+                htmlImg(src=contents),
+                htmlHr(),
+                htmlDiv('Raw Content'),
+                htmlPre(paste(substr(toJSON(contents), 1, 100), "..."), style=list(
+                  'whiteSpace'= 'pre-wrap',
+                  'wordBreak'= 'break-all'
+                ))
+              )))
+            }
+            
+            app$callback(
+              output = list(id='output-image-upload', property = 'children'),
+              params = list(input(id = 'upload-image', property = 'contents'),
+                            state(id = 'upload-image', property = 'filename'),
+                            state(id = 'upload-image', property = 'last_modified')),
+              function(list_of_contents, list_of_names, list_of_dates){
+                if (!is.null(list_of_contents) && !is.null(list_of_names) && !is.null(list_of_dates)) {
+                  children = lapply(1:length(list_of_contents), function(x){
+                    parse_content(list_of_contents[[x]], list_of_names[[x]], list_of_dates[[x]])
+                  })
+                }
+                return(children)
+              }
+            )
+            
+            app$run_server()
+    - name: dccGraph
+      dontrun: TRUE 
+      code: |
+            library(dash)
+            library(dashCoreComponents)
+            library(plotly)
+            
+            year <- c(1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003,
+              2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012)
+            
+            worldwide <- c(219, 146, 112, 127, 124, 180, 236, 207, 236, 263,
+              350, 430, 474, 526, 488, 537, 500, 439)
+            
+            china <- c(16, 13, 10, 11, 28, 37, 43, 55, 56, 88, 105, 156, 270,
+              299, 340, 403, 549, 499)
+            
+            data <- data.frame(year, worldwide, china)
+            
+            app$layout(
+              htmlDiv(
+                dccGraph(
+                  figure = layout(
+                             add_trace(
+                               plot_ly(data, 
+                                       x = ~year, 
+                                       y = ~worldwide,
+                                       type = "bar",
+                                       name = "Worldwide",
+                                       marker = list(color = "rgb(55, 83, 109)")
+                                      ), 
+                                      y = ~china, 
+                                      name = "China",
+                                      marker = list(color = "rgb(26, 118, 255)")
+                              ),
+                              yaxis = list(title = "Count"), 
+                              xaxis = list(title = "Year"),                               
+                              barmode = "group",
+                              title="US Export of Plastic Scrap"),
+                              style = list("height" = 300),
+                              id = "my_graph"
+                )
+              )
+            )
+            
+            app$run_server()
+    - name: dccRadioItems
+      dontrun: TRUE 
+      code: |       
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+            
+            app <- Dash$new()
+            
+            app$layout(
+              htmlDiv(
+                dccRadioItems(
+                  options=list(
+                    list("label" = "New York City", "value" = "NYC"),
+                    list("label" = "Montréal", "value" = "MTL"),
+                    list("label" = "San Francisco", "value" = "SF")
+                  ),
+                  value = "MTL"
+                )
+              )
+            )
+            
+            app$run_server()
+    - name: dccInput
+      dontrun: TRUE 
+      code: |       
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+            
+            app <- Dash$new()
+            
+            app$layout(
+              htmlDiv(
+                dccInput(
+                  placeholder = "Enter a value...",
+                  type = "text",
+                  value = ""
+                )
+              )
+            )
+            
+            app$run_server()            
+    - name: dccRangeSlider
+      dontrun: TRUE 
+      code: |     
+            library(dash)
+            library(dashHtmlComponents)
+            library(dashCoreComponents)
+            
+            app <- Dash$new()
+            
+            app$layout(
+              htmlDiv(
+                dccRangeSlider(
+                  count = 1,
+                  min = -5,
+                  max = 10,
+                  step = 0.5,
+                  value = list(-3, 7),
+                  marks = as.list(
+                    setNames(-5:10, as.character(-5:10))
+                  )
+                )
+              )
+            )
+            
+            app$run_server()

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -152,14 +152,6 @@ r_examples:
               })
             
             
-            app$callback(
-              output = list(id = 'output-confirm1', property = 'children'),
-              params=list(input(id = 'confirm', property = 'submit_n_clicks')),
-              function(n_clicks, value) {
-                if(length(n_clicks) == FALSE){
-                  sprintf('It wasnt easy but we did it %s', str(n_clicks))
-                }
-              })
             
             app$run_server()
     - name: dccLink


### PR DESCRIPTION
This PR proposes to contribute a complete set of R examples for the entire suite of `dashCoreComponents`. 

The majority of the examples included here mirror those found in the online documentation available at https://dashr.plot.ly, and are intended as as complement to those already in active use.

Since accent marks may cause headaches depending on the encoding of the system on which R is used, I have attempted to remove them from the corresponding `dash-info.yaml`.