### PR TITLE
Fix issues with multiple listeners on URL change

### DIFF
--- a/src/components/Location.react.js
+++ b/src/components/Location.react.js
@@ -84,15 +84,20 @@ export default class Location extends Component {
         }
     }
 
-    onLocationChange() {
-        const {setProps} = this.props;
-        setProps({
-            pathname: window.location.pathname,
-            href: window.location.href,
-            hash: window.location.hash,
-            search: window.location.search,
-        });
-
+    onLocationChange() {     
+        const {hash, href, pathname, refresh, search, setProps} = this.props;
+        if(search != window.location.search) {
+            setProps({search: window.location.search})
+        }
+        if(pathname != window.location.pathname) {
+            setProps({pathname: window.location.pathname})
+        }
+        if(hash != window.location.hash) {
+            setProps({hash: window.location.hash})
+        }
+        if(href != window.location.href) {
+            setProps({href: window.location.href})
+        } 
         History.dispatchChangeEvent();
     }
 


### PR DESCRIPTION
If two callbacks listen to two different parts of the URL, currently this means that both pages are going to be refreshed. This change fixes that by only setting those properties that have actually changed.

Following script is an example of the issue:

```python
import dash
from dash.dependencies import Input, Output
import dash_core_components as dcc
import dash_html_components as html

app = dash.Dash(__name__)

app.layout = html.Div([
    dcc.Location(
        id='location',
        refresh=False
    ),
    html.Div(id='output'),
    html.Div(id='output2')
])


@app.callback(Output('output', 'children'), [Input('location', 'pathname')])
def display_output(pathname):
    print(f"PATHNAME CALLBACK LOGGED: {pathname}")
    return dcc.Link(href='?test=test', children=[html.H2("Hey")], refresh=False)

@app.callback(Output('output2', 'children'), [Input('location', 'search')])
def display_output_search(search):
    print(f"SEARCH CALLBACK LOGGED: {search}")
    return "Hey"

if __name__ == '__main__':
    app.run_server(debug=True)
```
