### PR TITLE
Change dcc.Link for absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#768](https://github.com/plotly/dash-core-components/pull/768) Added title property to dcc.Link
 - [#776](https://github.com/plotly/dash-core-components/pull/776) Update dcc.Link to set href as children if children not defined. Makes href a required prop as well.
 - [#767](https://github.com/plotly/dash-core-components/pull/767) Updated dcc.Link to respond to click modifiers, and added a target prop.
+-[772](https://github.com/plotly/dash-core-components/pull/772) Modified dcc.Link to work with absolute paths if refresh=True.
 
 ## [1.8.1] -2020-02-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#776](https://github.com/plotly/dash-core-components/pull/776) Update dcc.Link to set href as children if children not defined. Makes href a required prop as well.
 - [#767](https://github.com/plotly/dash-core-components/pull/767) Updated dcc.Link to respond to click modifiers, and added a target prop.
 - [#774](https://github.com/plotly/dash-core-components/pull/774) Fixed dcc.Location firing callbacks for wrong property. 
-- [772](https://github.com/plotly/dash-core-components/pull/772) Modified dcc.Link to work with absolute paths if refresh=True.
+- [772](https://github.com/plotly/dash-core-components/pull/772) Modified dcc.Link to work with absolute paths if refresh=True. 
 
 ## [1.8.1] -2020-02-27
 ### Added

--- a/src/components/Link.react.js
+++ b/src/components/Link.react.js
@@ -54,7 +54,7 @@ export default class Link extends Component {
         // prevent anchor from updating location
         e.preventDefault();
         if (refresh) {
-            window.location.pathname = href;
+            window.location = href;
         } else {
             window.history.pushState({}, '', href);
             window.dispatchEvent(new CustomEvent('_dashprivate_pushstate'));

--- a/tests/integration/link/test_absolute_path.py
+++ b/tests/integration/link/test_absolute_path.py
@@ -1,0 +1,48 @@
+import pytest
+import dash
+from dash.dependencies import Input, Output
+import dash_core_components as dcc
+import dash_html_components as html
+
+
+@pytest.mark.DCC782
+def test_lipa001_path(dash_dcc):
+    app = dash.Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.Link("Relative Path", id="link1", href="google.com"),
+            dcc.Location(id="url", refresh=False),
+            html.Div(id="content")
+        ]
+    )
+    @app.callback(Output("content", "children"), [Input("url", "pathname")])
+    def display_children(children):
+        return children
+
+    dash_dcc.start_server(app)
+
+    dash_dcc.wait_for_element('#link1').click()
+
+    dash_dcc.wait_for_text_to_equal("#content", "/google.com")
+
+
+@pytest.mark.DCC782
+def test_lipa002_path(dash_dcc):
+    app = dash.Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.Link(children='Absolute Path', id="link1", href="https://google.com", refresh=True),
+            dcc.Location(id="url", refresh=False)
+        ]
+    )
+    dash_dcc.start_server(app)
+
+    dash_dcc.wait_for_element('#link1').click()
+
+    location = dash_dcc.driver.execute_script(
+        '''
+        return window.location.href
+        '''
+    )
+
+    assert location == 'https://www.google.com/'


### PR DESCRIPTION
This PR addresses #771 to open absolute paths directly with `dcc.Link` in the browser page with a refresh rather than appending it to the end of the pathname. 

Rather than `http://localhost/https://www.google.com`, it will now open `https://www.google.com` in the page.
