### PR TITLE
Expose Dropdown option 'title' property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] -
+## Changed
+- [#793](https://github.com/plotly/dash-core-components/pull/793) Added title key (i.e. HTML `title` attribute) to option dicts in `dcc.Dropdown` `options[]` list property.
+
 ## [1.9.1] - 2020-04-10
 ### Changed
 - [#740](https://github.com/plotly/dash-core-components/pull/740) Keep components that are loading in the DOM, but not visible, as opposed to removing them entirely. This will ensure that the size of the component's container does not shrink or expand when the component goes into the loading state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] -
-## Changed
+### Changed
 - [#793](https://github.com/plotly/dash-core-components/pull/793) Added title key (i.e. HTML `title` attribute) to option dicts in `dcc.Dropdown` `options[]` list property.
 
 ## [1.9.1] - 2020-04-10

--- a/src/components/Dropdown.react.js
+++ b/src/components/Dropdown.react.js
@@ -62,8 +62,7 @@ Dropdown.propTypes = {
              * information on hover. For more information on this attribute,
              * see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title
              */
-            title: PropTypes.string
-
+            title: PropTypes.string,
         })
     ),
 

--- a/src/components/Dropdown.react.js
+++ b/src/components/Dropdown.react.js
@@ -56,6 +56,14 @@ Dropdown.propTypes = {
              * If true, this option is disabled and cannot be selected.
              */
             disabled: PropTypes.bool,
+
+            /**
+             * The HTML 'title' attribute for the option. Allows for
+             * information on hover. For more information on this attribute,
+             * see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title
+             */
+            title: PropTypes.string
+
         })
     ),
 

--- a/tests/integration/dropdown/test_option_title_prop.py
+++ b/tests/integration/dropdown/test_option_title_prop.py
@@ -6,6 +6,7 @@ import dash_html_components as html
 
 from utils import wait_for
 
+
 @pytest.mark.DCC793
 @pytest.mark.parametrize("multi", [True, False])
 def test_ddot001_option_title(dash_dcc, multi):

--- a/tests/integration/dropdown/test_option_title_prop.py
+++ b/tests/integration/dropdown/test_option_title_prop.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 import pytest
 import dash
 from dash.dependencies import Input, Output

--- a/tests/integration/dropdown/test_option_title_prop.py
+++ b/tests/integration/dropdown/test_option_title_prop.py
@@ -1,0 +1,54 @@
+import pytest
+import dash
+from dash.dependencies import Input, Output
+import dash_core_components as dcc
+import dash_html_components as html
+
+from utils import wait_for
+
+@pytest.mark.DCC793
+@pytest.mark.parametrize("multi", [True, False])
+def test_ddot001_option_title(dash_dcc, multi):
+    app = dash.Dash(__name__)
+    app.layout = html.Div([
+        dcc.Input(
+            id="dropdown_title_input",
+            type="text",
+            placeholder="Enter a title for New York City"
+        ),
+        dcc.Dropdown(
+            id="dropdown",
+            options=[
+                {'label': 'New York City', 'value': 'NYC'},
+                {'label': 'Montréal', 'value': 'MTL'},
+                {'label': 'San Francisco', 'value': 'SF'}
+            ],
+            value='NYC',
+            multi=multi
+        )
+    ])
+
+    @app.callback(Output("dropdown", "options"), [Input("dropdown_title_input", "value")])
+    def add_title_to_option(title):
+        return [
+            {'label': 'New York City', 'title': title, 'value': 'NYC'},
+            {'label': 'Montréal', 'value': 'MTL'},
+            {'label': 'San Francisco', 'value': 'SF'}
+        ]
+
+    dash_dcc.start_server(app)
+
+    dropdown_option_element = dash_dcc.wait_for_element("#dropdown .Select-value")
+
+    dropdown_title_input = dash_dcc.wait_for_element("#dropdown_title_input")
+
+    dropdown_title_input.send_keys("The Big Apple")
+
+    wait_for(
+        lambda: dropdown_option_element.get_attribute("title")
+        == "The Big Apple",
+        lambda: '`title` is {}, expected {}'.format(
+            dropdown_option_element.get_attribute("title"),
+            "The Big Apple",
+        ),
+    )

--- a/tests/integration/dropdown/test_option_title_prop.py
+++ b/tests/integration/dropdown/test_option_title_prop.py
@@ -45,6 +45,16 @@ def test_ddot001_option_title(dash_dcc, multi):
 
     dropdown_title_input = dash_dcc.wait_for_element("#dropdown_title_input")
 
+    # Empty string title ('') (default for no title)
+    wait_for(
+        lambda: dropdown_option_element.get_attribute("title")
+        == '',
+        lambda: '`title` is {}, expected {}'.format(
+            dropdown_option_element.get_attribute("title"),
+            '',
+        ),
+    )
+
     dropdown_title_input.send_keys("The Big Apple")
 
     wait_for(
@@ -53,5 +63,29 @@ def test_ddot001_option_title(dash_dcc, multi):
         lambda: '`title` is {}, expected {}'.format(
             dropdown_option_element.get_attribute("title"),
             "The Big Apple",
+        ),
+    )
+
+    dropdown_title_input.clear()
+
+    dropdown_title_input.send_keys("Gotham City?")
+
+    wait_for(
+        lambda: dropdown_option_element.get_attribute("title")
+        == "Gotham City?",
+        lambda: '`title` is {}, expected {}'.format(
+            dropdown_option_element.get_attribute("title"),
+            "Gotham City?",
+        ),
+    )
+
+    dropdown_title_input.clear()
+
+    wait_for(
+        lambda: dropdown_option_element.get_attribute("title")
+        == '',
+        lambda: '`title` is {}, expected {}'.format(
+            dropdown_option_element.get_attribute("title"),
+            '',
         ),
     )

--- a/tests/integration/dropdown/test_option_title_prop.py
+++ b/tests/integration/dropdown/test_option_title_prop.py
@@ -69,7 +69,7 @@ def test_ddot001_option_title(dash_dcc, multi):
 
     # For some reason, element.clear() doesn't work on either Chrome or CircleCI
     dropdown_title_input.send_keys(Keys.CONTROL + "a")
-    dropdown_title_input.send_keys(Keys.DELETE);
+    dropdown_title_input.send_keys(Keys.DELETE)
 
     dropdown_title_input.send_keys("Gotham City?")
 
@@ -83,7 +83,7 @@ def test_ddot001_option_title(dash_dcc, multi):
     )
 
     dropdown_title_input.send_keys(Keys.CONTROL + "a")
-    dropdown_title_input.send_keys(Keys.DELETE);
+    dropdown_title_input.send_keys(Keys.DELETE)
 
     wait_for(
         lambda: dropdown_option_element.get_attribute("title")

--- a/tests/integration/dropdown/test_option_title_prop.py
+++ b/tests/integration/dropdown/test_option_title_prop.py
@@ -7,7 +7,6 @@ import dash_core_components as dcc
 import dash_html_components as html
 
 from utils import wait_for
-from selenium.webdriver.common.keys import Keys
 
 
 @pytest.mark.DCC793
@@ -67,9 +66,7 @@ def test_ddot001_option_title(dash_dcc, multi):
         ),
     )
 
-    # For some reason, element.clear() doesn't work on either Chrome or CircleCI
-    dropdown_title_input.send_keys(Keys.CONTROL + "a")
-    dropdown_title_input.send_keys(Keys.DELETE)
+    dash_dcc.clear_input(dropdown_title_input)
 
     dropdown_title_input.send_keys("Gotham City?")
 
@@ -82,8 +79,7 @@ def test_ddot001_option_title(dash_dcc, multi):
         ),
     )
 
-    dropdown_title_input.send_keys(Keys.CONTROL + "a")
-    dropdown_title_input.send_keys(Keys.DELETE)
+    dash_dcc.clear_input(dropdown_title_input)
 
     wait_for(
         lambda: dropdown_option_element.get_attribute("title")

--- a/tests/integration/dropdown/test_option_title_prop.py
+++ b/tests/integration/dropdown/test_option_title_prop.py
@@ -7,6 +7,7 @@ import dash_core_components as dcc
 import dash_html_components as html
 
 from utils import wait_for
+from selenium.webdriver.common.keys import Keys
 
 
 @pytest.mark.DCC793
@@ -66,7 +67,9 @@ def test_ddot001_option_title(dash_dcc, multi):
         ),
     )
 
-    dropdown_title_input.clear()
+    # For some reason, element.clear() doesn't work on either Chrome or CircleCI
+    dropdown_title_input.send_keys(Keys.CONTROL + "a")
+    dropdown_title_input.send_keys(Keys.DELETE);
 
     dropdown_title_input.send_keys("Gotham City?")
 
@@ -79,7 +82,8 @@ def test_ddot001_option_title(dash_dcc, multi):
         ),
     )
 
-    dropdown_title_input.clear()
+    dropdown_title_input.send_keys(Keys.CONTROL + "a")
+    dropdown_title_input.send_keys(Keys.DELETE);
 
     wait_for(
         lambda: dropdown_option_element.get_attribute("title")


### PR DESCRIPTION
The HTML property `title` is already available upstream in `react-virtualized-select`:

https://github.com/bvaughn/react-virtualized-select/blob/master/source/VirtualizedSelect/VirtualizedSelect.js#L186

So I exposed it in the Dropdown component as a solution was requested by @KPhans:

>  is there a way to have hover descriptions of dropwdown selections?

If the core team is on board with this I'll add an integration test and a docs example.

Demo:

![title](https://user-images.githubusercontent.com/9068290/79368889-1cf84300-7f1e-11ea-821e-ce0bf67d7cbd.gif)


