### PR TITLE
Update Graph component as `loading_state` changes

### DIFF
--- a/src/fragments/Graph.react.js
+++ b/src/fragments/Graph.react.js
@@ -71,7 +71,7 @@ const filterEventData = (gd, eventData, event) => {
 
         for (let i = 0; i < eventData.points.length; i++) {
             const fullPoint = eventData.points[i];
-            const pointData = filter(function(o) {
+            const pointData = filter(function (o) {
                 return !includes(type(o), ['Object', 'Array']);
             }, fullPoint);
             if (
@@ -191,7 +191,7 @@ class PlotlyGraph extends Component {
     extend(props) {
         const {clearExtendData, extendData: extendDataArray} = props;
 
-        extendDataArray.forEach(extendData => {
+        extendDataArray.forEach((extendData) => {
             let updateData, traceIndices, maxPoints;
             if (
                 Array.isArray(extendData) &&
@@ -299,26 +299,26 @@ class PlotlyGraph extends Component {
 
         const gd = this.gd.current;
 
-        gd.on('plotly_click', eventData => {
+        gd.on('plotly_click', (eventData) => {
             const clickData = filterEventData(gd, eventData, 'click');
             if (!isNil(clickData)) {
                 setProps({clickData});
             }
         });
-        gd.on('plotly_clickannotation', eventData => {
+        gd.on('plotly_clickannotation', (eventData) => {
             const clickAnnotationData = omit(
                 ['event', 'fullAnnotation'],
                 eventData
             );
             setProps({clickAnnotationData});
         });
-        gd.on('plotly_hover', eventData => {
+        gd.on('plotly_hover', (eventData) => {
             const hover = filterEventData(gd, eventData, 'hover');
             if (!isNil(hover) && !equals(hover, hoverData)) {
                 setProps({hoverData: hover});
             }
         });
-        gd.on('plotly_selected', eventData => {
+        gd.on('plotly_selected', (eventData) => {
             const selected = filterEventData(gd, eventData, 'selected');
             if (!isNil(selected) && !equals(selected, selectedData)) {
                 setProps({selectedData: selected});
@@ -327,13 +327,13 @@ class PlotlyGraph extends Component {
         gd.on('plotly_deselect', () => {
             setProps({selectedData: null});
         });
-        gd.on('plotly_relayout', eventData => {
+        gd.on('plotly_relayout', (eventData) => {
             const relayout = filterEventData(gd, eventData, 'relayout');
             if (!isNil(relayout) && !equals(relayout, relayoutData)) {
                 setProps({relayoutData: relayout});
             }
         });
-        gd.on('plotly_restyle', eventData => {
+        gd.on('plotly_restyle', (eventData) => {
             const restyle = filterEventData(gd, eventData, 'restyle');
             if (!isNil(restyle) && !equals(restyle, restyleData)) {
                 setProps({restyleData: restyle});
@@ -366,8 +366,10 @@ class PlotlyGraph extends Component {
     shouldComponentUpdate(nextProps) {
         return (
             this.props.id !== nextProps.id ||
-            JSON.stringify(this.props.style) !== JSON.stringify(nextProps.style) ||
-            JSON.stringify(this.props.loading_state) !== JSON.stringify(nextProps.loading_state)
+            JSON.stringify(this.props.style) !==
+                JSON.stringify(nextProps.style) ||
+            JSON.stringify(this.props.loading_state) !==
+                JSON.stringify(nextProps.loading_state)
         );
     }
 

--- a/src/fragments/Graph.react.js
+++ b/src/fragments/Graph.react.js
@@ -71,7 +71,7 @@ const filterEventData = (gd, eventData, event) => {
 
         for (let i = 0; i < eventData.points.length; i++) {
             const fullPoint = eventData.points[i];
-            const pointData = filter(function (o) {
+            const pointData = filter(function(o) {
                 return !includes(type(o), ['Object', 'Array']);
             }, fullPoint);
             if (
@@ -191,7 +191,7 @@ class PlotlyGraph extends Component {
     extend(props) {
         const {clearExtendData, extendData: extendDataArray} = props;
 
-        extendDataArray.forEach((extendData) => {
+        extendDataArray.forEach(extendData => {
             let updateData, traceIndices, maxPoints;
             if (
                 Array.isArray(extendData) &&
@@ -299,26 +299,26 @@ class PlotlyGraph extends Component {
 
         const gd = this.gd.current;
 
-        gd.on('plotly_click', (eventData) => {
+        gd.on('plotly_click', eventData => {
             const clickData = filterEventData(gd, eventData, 'click');
             if (!isNil(clickData)) {
                 setProps({clickData});
             }
         });
-        gd.on('plotly_clickannotation', (eventData) => {
+        gd.on('plotly_clickannotation', eventData => {
             const clickAnnotationData = omit(
                 ['event', 'fullAnnotation'],
                 eventData
             );
             setProps({clickAnnotationData});
         });
-        gd.on('plotly_hover', (eventData) => {
+        gd.on('plotly_hover', eventData => {
             const hover = filterEventData(gd, eventData, 'hover');
             if (!isNil(hover) && !equals(hover, hoverData)) {
                 setProps({hoverData: hover});
             }
         });
-        gd.on('plotly_selected', (eventData) => {
+        gd.on('plotly_selected', eventData => {
             const selected = filterEventData(gd, eventData, 'selected');
             if (!isNil(selected) && !equals(selected, selectedData)) {
                 setProps({selectedData: selected});
@@ -327,13 +327,13 @@ class PlotlyGraph extends Component {
         gd.on('plotly_deselect', () => {
             setProps({selectedData: null});
         });
-        gd.on('plotly_relayout', (eventData) => {
+        gd.on('plotly_relayout', eventData => {
             const relayout = filterEventData(gd, eventData, 'relayout');
             if (!isNil(relayout) && !equals(relayout, relayoutData)) {
                 setProps({relayoutData: relayout});
             }
         });
-        gd.on('plotly_restyle', (eventData) => {
+        gd.on('plotly_restyle', eventData => {
             const restyle = filterEventData(gd, eventData, 'restyle');
             if (!isNil(restyle) && !equals(restyle, restyleData)) {
                 setProps({restyleData: restyle});

--- a/src/fragments/Graph.react.js
+++ b/src/fragments/Graph.react.js
@@ -366,7 +366,8 @@ class PlotlyGraph extends Component {
     shouldComponentUpdate(nextProps) {
         return (
             this.props.id !== nextProps.id ||
-            JSON.stringify(this.props.style) !== JSON.stringify(nextProps.style)
+            JSON.stringify(this.props.style) !== JSON.stringify(nextProps.style) ||
+            JSON.stringify(this.props.loading_state) !== JSON.stringify(nextProps.loading_state)
         );
     }
 

--- a/tests/integration/graph/test_graph_basics.py
+++ b/tests/integration/graph/test_graph_basics.py
@@ -1,6 +1,6 @@
 import pytest
 import pandas as pd
-from multiprocessing import Value
+from multiprocessing import Value, Lock
 import numpy as np
 from time import sleep
 
@@ -133,5 +133,50 @@ def test_grbs003_graph_wrapped_in_loading_component_does_not_fail(dash_dcc):
     dash_dcc.start_server(app)
 
     dash_dcc.wait_for_element('#my-graph .main-svg')
+
+    assert not dash_dcc.get_logs()
+
+
+@pytest.mark.DCC837
+def test_grbs004_graph_loading_state_updates(dash_dcc):
+    lock = Lock()
+    app = dash.Dash(__name__, suppress_callback_exceptions=True)
+    app.layout = html.Div([
+        html.H1(id='title', children='loading state updates'),
+        dcc.Graph(id='my-graph'),
+    ])
+
+    @app.callback(Output('my-graph', 'figure'), [Input('title', 'n_clicks')])
+    def update_graph(n_clicks):
+        values = [0, n_clicks]
+        ranges = [0, n_clicks]
+
+        with lock:
+            return {
+                'data': [{
+                    'x': ranges,
+                    'y': values,
+                    'line': {
+                        'shape': 'spline'
+                    }
+                }],
+            }
+
+    with lock:
+        dash_dcc.start_server(app)
+
+        my_graph = dash_dcc.wait_for_element('#my-graph')
+
+        assert not my_graph.get_attribute('data-dash-is-loading')
+
+        title = dash_dcc.wait_for_element('#title')
+
+        title.click()
+
+        dash_dcc.wait_for_element('#my-graph[data-dash-is-loading="true"]')
+
+    my_graph = dash_dcc.wait_for_element('#my-graph')
+
+    assert not my_graph.get_attribute('data-dash-is-loading')
 
     assert not dash_dcc.get_logs()

--- a/tests/integration/graph/test_graph_basics.py
+++ b/tests/integration/graph/test_graph_basics.py
@@ -162,21 +162,14 @@ def test_grbs004_graph_loading_state_updates(dash_dcc):
                 }],
             }
 
+    dash_dcc.start_server(app)
+    dash_dcc.wait_for_element('#my-graph:not([data-dash-is-loading])')
+
     with lock:
-        dash_dcc.start_server(app)
-
-        my_graph = dash_dcc.wait_for_element('#my-graph')
-
-        assert not my_graph.get_attribute('data-dash-is-loading')
-
         title = dash_dcc.wait_for_element('#title')
-
         title.click()
-
         dash_dcc.wait_for_element('#my-graph[data-dash-is-loading="true"]')
 
-    my_graph = dash_dcc.wait_for_element('#my-graph')
-
-    assert not my_graph.get_attribute('data-dash-is-loading')
+    dash_dcc.wait_for_element('#my-graph:not([data-dash-is-loading])')
 
     assert not dash_dcc.get_logs()


### PR DESCRIPTION
This fixes an issue where the `dcc.Graph` element would not appropriately update `[data-dash-is-loading]`. 
This was experienced in our production `dash` deployment, and has been reported by other folks in #632 

The attached test case fails consistently in `1.10.1` & passes consistently in this feature branch.
The behavior works as expected using this patch in production application.

Let me know if you have a better approach to the integration test assertions for toggling between loading/not loading. 

Cheers~