### PR TITLE
Fix string comparison for lint:black in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "private::format:black": "black --exclude dash_core_components .",
     "private::format.eslint": "eslint src tests --fix",
     "private::format.prettier": "prettier --config .prettierrc --write src/**/*.js tests/unit/*.js",
-    "private::lint:black": "if [[ PYTHON_VERSION != 'py27' ]]; then black --check --exclude dash_core_components .; fi",
+    "private::lint:black": "if [ \"$PYTHON_VERSION\" != \"py27\" ]; then black --check --exclude dash_core_components .; fi",
     "private::lint.eslint": "eslint src tests",
     "private::lint.flake8": "flake8 --exclude=dash_core_components,node_modules,venv",
     "private::lint.prettier": "prettier --config .prettierrc src/**/*.js tests/unit/*.js --list-different",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "homepage": "https://github.com/plotly/dash-core-components",
   "main": "dash_core_components/dash_core_components.min.js",
   "scripts": {
-    "private::format:black": "black --exclude dash_core_components .",
+    "private::format.black": "black --exclude dash_core_components .",
     "private::format.eslint": "eslint src tests --fix",
     "private::format.prettier": "prettier --config .prettierrc --write src/**/*.js tests/unit/*.js",
-    "private::lint:black": "if [ \"$PYTHON_VERSION\" != \"py27\" ]; then black --check --exclude dash_core_components .; fi",
+    "private::lint.black": "if [ \"$PYTHON_VERSION\" != \"py27\" ]; then black --check --exclude dash_core_components .; fi",
     "private::lint.eslint": "eslint src tests",
     "private::lint.flake8": "flake8 --exclude=dash_core_components,node_modules,venv",
     "private::lint.prettier": "prettier --config .prettierrc src/**/*.js tests/unit/*.js --list-different",

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,19 @@
 from setuptools import setup
 import json
 
-with open('package.json') as f:
+with open("package.json") as f:
     package = json.load(f)
 
 package_name = str(package["name"].replace(" ", "_").replace("-", "_"))
 
 setup(
-    name='dash_core_components',
+    name="dash_core_components",
     version=package["version"],
-    author=package['author'],
-    author_email='chris@plotly.com',
+    author=package["author"],
+    author_email="chris@plotly.com",
     packages=[package_name],
     include_package_data=True,
-    license=package['license'],
+    license=package["license"],
     description=package.get("description", package_name),
-    install_requires=[]
+    install_requires=[],
 )

--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -15,23 +15,22 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 
 class IntegrationTests(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         super(IntegrationTests, cls).setUpClass()
 
         options = Options()
         capabilities = DesiredCapabilities.CHROME
-        capabilities['loggingPrefs'] = {'browser': 'SEVERE'}
+        capabilities["loggingPrefs"] = {"browser": "SEVERE"}
 
-        if 'DASH_TEST_CHROMEPATH' in os.environ:
-            options.binary_location = os.environ['DASH_TEST_CHROMEPATH']
+        if "DASH_TEST_CHROMEPATH" in os.environ:
+            options.binary_location = os.environ["DASH_TEST_CHROMEPATH"]
 
-        cls.driver = webdriver.Chrome(options=options, desired_capabilities=capabilities)
+        cls.driver = webdriver.Chrome(
+            options=options, desired_capabilities=capabilities
+        )
         loader = percy.ResourceLoader(
-            webdriver=cls.driver,
-            base_url='/assets',
-            root_dir='tests/assets'
+            webdriver=cls.driver, base_url="/assets", root_dir="tests/assets"
         )
         cls.percy_runner = percy.Runner(loader=loader)
         cls.percy_runner.initialize_build()
@@ -45,8 +44,8 @@ class IntegrationTests(unittest.TestCase):
         pass
 
     def tearDown(self):
-        if platform.system() == 'Windows':
-            requests.get('http://localhost:8050/stop')
+        if platform.system() == "Windows":
+            requests.get("http://localhost:8050/stop")
         else:
             self.server_process.terminate()
 
@@ -60,8 +59,8 @@ class IntegrationTests(unittest.TestCase):
         :type app: dash.Dash
         :return:
         """
-        if 'DASH_TEST_PROCESSES' in os.environ:
-            processes = int(os.environ['DASH_TEST_PROCESSES'])
+        if "DASH_TEST_PROCESSES" in os.environ:
+            processes = int(os.environ["DASH_TEST_PROCESSES"])
         else:
             processes = 4
 
@@ -76,29 +75,25 @@ class IntegrationTests(unittest.TestCase):
                 use_reloader=False,
                 use_debugger=True,
                 dev_tools_hot_reload=False,
-                dev_tools_ui=False
+                dev_tools_ui=False,
             )
 
         def run_windows():
             app.scripts.config.serve_locally = True
             app.css.config.serve_locally = True
 
-            @app.server.route('/stop')
+            @app.server.route("/stop")
             def _stop_server_windows():
-                stopper = flask.request.environ['werkzeug.server.shutdown']
+                stopper = flask.request.environ["werkzeug.server.shutdown"]
                 stopper()
-                return 'stop'
+                return "stop"
 
-            app.run_server(
-                port=8050,
-                debug=False,
-                threaded=True
-            )
+            app.run_server(port=8050, debug=False, threaded=True)
 
         # Run on a separate process so that it doesn't block
 
         system = platform.system()
-        if system == 'Windows':
+        if system == "Windows":
             # multiprocess can't pickle an inner func on windows (closure are not serializable by default on windows)
             self.server_thread = threading.Thread(target=run_windows)
             self.server_thread.start()
@@ -109,7 +104,7 @@ class IntegrationTests(unittest.TestCase):
 
         # Visit the dash page
         self.driver.implicitly_wait(2)
-        self.driver.get('http://localhost:8050')
+        self.driver.get("http://localhost:8050")
 
     def clear_log(self):
         entries = self.driver.get_log("browser")

--- a/tests/integration/calendar/test_calendar_props.py
+++ b/tests/integration/calendar/test_calendar_props.py
@@ -31,9 +31,7 @@ def test_cdpr001_date_clearable_true_works(dash_dcc):
 
     close_btn.click()
     start_date, end_date = dash_dcc.get_date_range("dpr")
-    assert (
-        not start_date and not end_date
-    ), "both start and end dates should be cleared"
+    assert not start_date and not end_date, "both start and end dates should be cleared"
 
     # DPS
     selected = dash_dcc.select_date_single("dps", day="1")
@@ -41,7 +39,7 @@ def test_cdpr001_date_clearable_true_works(dash_dcc):
     assert selected, "single date should get a value"
     close_btn = dash_dcc.wait_for_element("#dps button")
     close_btn.click()
-    single_date, = dash_dcc.get_date_range("dps")
+    (single_date,) = dash_dcc.get_date_range("dps")
     assert not single_date, "date should be cleared"
 
 

--- a/tests/integration/calendar/test_date_picker_range.py
+++ b/tests/integration/calendar/test_date_picker_range.py
@@ -7,14 +7,16 @@ import dash_core_components as dcc
 
 def test_dtpr001_initial_month_provided(dash_dcc):
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        dcc.DatePickerRange(
-            id="dps-initial-month",
-            min_date_allowed=datetime(2010, 1, 1),
-            max_date_allowed=datetime(2099, 12, 31),
-            initial_visible_month=datetime(2019, 10, 28)
-        )
-    ])
+    app.layout = html.Div(
+        [
+            dcc.DatePickerRange(
+                id="dps-initial-month",
+                min_date_allowed=datetime(2010, 1, 1),
+                max_date_allowed=datetime(2099, 12, 31),
+                initial_visible_month=datetime(2019, 10, 28),
+            )
+        ]
+    )
 
     dash_dcc.start_server(app)
 
@@ -24,21 +26,23 @@ def test_dtpr001_initial_month_provided(dash_dcc):
     date_picker_start.click()
 
     dash_dcc.wait_for_text_to_equal(
-        '#dps-initial-month .CalendarMonth.CalendarMonth_1[data-visible=true] strong',
-        'October 2019',
-        1
+        "#dps-initial-month .CalendarMonth.CalendarMonth_1[data-visible=true] strong",
+        "October 2019",
+        1,
     )
 
 
 def test_dtpr002_no_initial_month_min_date(dash_dcc):
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        dcc.DatePickerRange(
-            id="dps-initial-month",
-            min_date_allowed=datetime(2010, 1, 1),
-            max_date_allowed=datetime(2099, 12, 31)
-        )
-    ])
+    app.layout = html.Div(
+        [
+            dcc.DatePickerRange(
+                id="dps-initial-month",
+                min_date_allowed=datetime(2010, 1, 1),
+                max_date_allowed=datetime(2099, 12, 31),
+            )
+        ]
+    )
 
     dash_dcc.start_server(app)
 
@@ -48,20 +52,22 @@ def test_dtpr002_no_initial_month_min_date(dash_dcc):
     date_picker_start.click()
 
     dash_dcc.wait_for_text_to_equal(
-        '#dps-initial-month .CalendarMonth.CalendarMonth_1[data-visible=true] strong',
-        'January 2010'
+        "#dps-initial-month .CalendarMonth.CalendarMonth_1[data-visible=true] strong",
+        "January 2010",
     )
 
 
 def test_dtpr003_no_initial_month_no_min_date_start_date(dash_dcc):
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        dcc.DatePickerRange(
-            id="dps-initial-month",
-            start_date=datetime(2019, 8, 13),
-            max_date_allowed=datetime(2099, 12, 31)
-        )
-    ])
+    app.layout = html.Div(
+        [
+            dcc.DatePickerRange(
+                id="dps-initial-month",
+                start_date=datetime(2019, 8, 13),
+                max_date_allowed=datetime(2099, 12, 31),
+            )
+        ]
+    )
 
     dash_dcc.start_server(app)
 
@@ -71,6 +77,6 @@ def test_dtpr003_no_initial_month_no_min_date_start_date(dash_dcc):
     date_picker_start.click()
 
     dash_dcc.wait_for_text_to_equal(
-        '#dps-initial-month .CalendarMonth.CalendarMonth_1[data-visible=true] strong',
-        'August 2019'
+        "#dps-initial-month .CalendarMonth.CalendarMonth_1[data-visible=true] strong",
+        "August 2019",
     )

--- a/tests/integration/calendar/test_date_picker_single.py
+++ b/tests/integration/calendar/test_date_picker_single.py
@@ -17,8 +17,7 @@ def test_dtps001_simple_click(dash_dcc):
                 id="dps",
                 min_date_allowed=datetime(2010, 1, 1),
                 max_date_allowed=datetime(2099, 12, 31),
-                initial_visible_month=datetime.today().date()
-                - timedelta(days=1),
+                initial_visible_month=datetime.today().date() - timedelta(days=1),
                 day_size=47,
             ),
         ],
@@ -65,11 +64,8 @@ def test_dtps010_local_and_session_persistence(dash_dcc):
         session = dash_dcc.select_date_single("dps-session", index=idx)
         dash_dcc.wait_for_page()
         assert (
-            dash_dcc.find_element("#dps-local input").get_attribute("value")
-            == local
-            and dash_dcc.find_element("#dps-session input").get_attribute(
-                "value"
-            )
+            dash_dcc.find_element("#dps-local input").get_attribute("value") == local
+            and dash_dcc.find_element("#dps-session input").get_attribute("value")
             == session
         ), "the date value should be consistent after refresh"
 
@@ -90,8 +86,7 @@ def test_dtps011_memory_persistence(dash_dcc):
                     id="dps-memory",
                     min_date_allowed=datetime(2010, 1, 1),
                     max_date_allowed=datetime(2099, 12, 31),
-                    initial_visible_month=datetime.today().date()
-                    - timedelta(days=1),
+                    initial_visible_month=datetime.today().date() - timedelta(days=1),
                     persistence=True,
                     persistence_type="memory",
                     day_size=47,
@@ -100,8 +95,7 @@ def test_dtps011_memory_persistence(dash_dcc):
                     id="dps-none",
                     min_date_allowed=datetime(2010, 1, 1),
                     max_date_allowed=datetime(2099, 12, 31),
-                    initial_visible_month=datetime.today().date()
-                    - timedelta(days=1),
+                    initial_visible_month=datetime.today().date() - timedelta(days=1),
                     day_size=47,
                 ),
             ]
@@ -120,8 +114,7 @@ def test_dtps011_memory_persistence(dash_dcc):
     assert dash_dcc.wait_for_text_to_equal("#out", "switched")
     switch.click()
     assert (
-        dash_dcc.find_element("#dps-memory input").get_attribute("value")
-        == memorized
+        dash_dcc.find_element("#dps-memory input").get_attribute("value") == memorized
     )
     switched = dash_dcc.find_element("#dps-none input").get_attribute("value")
     assert switched != amnesiaed and switched == ""
@@ -129,19 +122,21 @@ def test_dtps011_memory_persistence(dash_dcc):
 
 def test_dtps012_initial_month(dash_dcc):
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        dcc.DatePickerSingle(
-            id="dps-initial-month",
-            min_date_allowed=datetime(2010, 1, 1),
-            max_date_allowed=datetime(2099, 12, 31)
-        )
-    ])
+    app.layout = html.Div(
+        [
+            dcc.DatePickerSingle(
+                id="dps-initial-month",
+                min_date_allowed=datetime(2010, 1, 1),
+                max_date_allowed=datetime(2099, 12, 31),
+            )
+        ]
+    )
 
     dash_dcc.start_server(app)
 
-    date_picker = dash_dcc.find_element('#dps-initial-month')
+    date_picker = dash_dcc.find_element("#dps-initial-month")
     date_picker.click()
     dash_dcc.wait_for_text_to_equal(
-        '#dps-initial-month .CalendarMonth.CalendarMonth_1[data-visible=true] strong',
-        'January 2010'
+        "#dps-initial-month .CalendarMonth.CalendarMonth_1[data-visible=true] strong",
+        "January 2010",
     )

--- a/tests/integration/dropdown/test_clearable_false.py
+++ b/tests/integration/dropdown/test_clearable_false.py
@@ -8,71 +8,69 @@ from selenium.webdriver.common.keys import Keys
 
 def test_ddcf001_clearable_false_single(dash_duo):
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        dcc.Dropdown(
-            id='my-unclearable-dropdown',
-            options=[
-                {'label': 'New York City', 'value': 'NYC'},
-                {'label': 'Montreal', 'value': 'MTL'},
-                {'label': 'San Francisco', 'value': 'SF'},
-            ],
-            value='MTL',
-            clearable=False
-        ),
-        html.Div(
-            id='dropdown-value',
-            style={'height': '10px', 'width': '10px'}
-        )
-    ])
+    app.layout = html.Div(
+        [
+            dcc.Dropdown(
+                id="my-unclearable-dropdown",
+                options=[
+                    {"label": "New York City", "value": "NYC"},
+                    {"label": "Montreal", "value": "MTL"},
+                    {"label": "San Francisco", "value": "SF"},
+                ],
+                value="MTL",
+                clearable=False,
+            ),
+            html.Div(id="dropdown-value", style={"height": "10px", "width": "10px"}),
+        ]
+    )
 
     @app.callback(
-        Output('dropdown-value', 'children'),
-        [Input('my-unclearable-dropdown', 'value')]
+        Output("dropdown-value", "children"),
+        [Input("my-unclearable-dropdown", "value")],
     )
     def update_value(val):
         return val
 
     dash_duo.start_server(app)
 
-    dropdown = dash_duo.find_element('#my-unclearable-dropdown input')
+    dropdown = dash_duo.find_element("#my-unclearable-dropdown input")
     dropdown.send_keys(Keys.BACKSPACE)
-    dash_duo.find_element('#dropdown-value').click()
+    dash_duo.find_element("#dropdown-value").click()
 
-    assert len(dash_duo.find_element('#dropdown-value').text) > 0
+    assert len(dash_duo.find_element("#dropdown-value").text) > 0
 
 
 def test_ddcf002_clearable_false_multi(dash_duo):
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        dcc.Dropdown(
-            id='my-unclearable-dropdown',
-            options=[
-                {'label': 'New York City', 'value': 'NYC'},
-                {'label': 'Montreal', 'value': 'MTL'},
-                {'label': 'San Francisco', 'value': 'SF'},
-            ],
-            value=['MTL', 'SF'],
-            multi=True,
-            clearable=False
-        ),
-        html.Div(
-            id='dropdown-value',
-            style={'height': '10px', 'width': '10px'}
-        )
-    ])
+    app.layout = html.Div(
+        [
+            dcc.Dropdown(
+                id="my-unclearable-dropdown",
+                options=[
+                    {"label": "New York City", "value": "NYC"},
+                    {"label": "Montreal", "value": "MTL"},
+                    {"label": "San Francisco", "value": "SF"},
+                ],
+                value=["MTL", "SF"],
+                multi=True,
+                clearable=False,
+            ),
+            html.Div(id="dropdown-value", style={"height": "10px", "width": "10px"}),
+        ]
+    )
 
     @app.callback(
-        Output('dropdown-value', 'children'),
-        [Input('my-unclearable-dropdown', 'value')]
+        Output("dropdown-value", "children"),
+        [Input("my-unclearable-dropdown", "value")],
     )
     def update_value(val):
-        return ', '.join(val)
+        return ", ".join(val)
 
     dash_duo.start_server(app)
 
-    dropdown = dash_duo.find_element('#my-unclearable-dropdown input')
+    dropdown = dash_duo.find_element("#my-unclearable-dropdown input")
     dropdown.send_keys(Keys.BACKSPACE)
     dropdown.send_keys(Keys.BACKSPACE)
-    dash_duo.find_element('#dropdown-value').click()
+    dash_duo.find_element("#dropdown-value").click()
 
-    assert len(dash_duo.find_element('#dropdown-value').text) > 0
+    assert len(dash_duo.find_element("#dropdown-value").text) > 0

--- a/tests/integration/dropdown/test_option_title_prop.py
+++ b/tests/integration/dropdown/test_option_title_prop.py
@@ -13,30 +13,34 @@ from utils import wait_for
 @pytest.mark.parametrize("multi", [True, False])
 def test_ddot001_option_title(dash_dcc, multi):
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        dcc.Input(
-            id="dropdown_title_input",
-            type="text",
-            placeholder="Enter a title for New York City"
-        ),
-        dcc.Dropdown(
-            id="dropdown",
-            options=[
-                {'label': 'New York City', 'value': 'NYC'},
-                {'label': 'Montréal', 'value': 'MTL'},
-                {'label': 'San Francisco', 'value': 'SF'}
-            ],
-            value='NYC',
-            multi=multi
-        )
-    ])
+    app.layout = html.Div(
+        [
+            dcc.Input(
+                id="dropdown_title_input",
+                type="text",
+                placeholder="Enter a title for New York City",
+            ),
+            dcc.Dropdown(
+                id="dropdown",
+                options=[
+                    {"label": "New York City", "value": "NYC"},
+                    {"label": "Montréal", "value": "MTL"},
+                    {"label": "San Francisco", "value": "SF"},
+                ],
+                value="NYC",
+                multi=multi,
+            ),
+        ]
+    )
 
-    @app.callback(Output("dropdown", "options"), [Input("dropdown_title_input", "value")])
+    @app.callback(
+        Output("dropdown", "options"), [Input("dropdown_title_input", "value")]
+    )
     def add_title_to_option(title):
         return [
-            {'label': 'New York City', 'title': title, 'value': 'NYC'},
-            {'label': 'Montréal', 'value': 'MTL'},
-            {'label': 'San Francisco', 'value': 'SF'}
+            {"label": "New York City", "title": title, "value": "NYC"},
+            {"label": "Montréal", "value": "MTL"},
+            {"label": "San Francisco", "value": "SF"},
         ]
 
     dash_dcc.start_server(app)
@@ -47,22 +51,18 @@ def test_ddot001_option_title(dash_dcc, multi):
 
     # Empty string title ('') (default for no title)
     wait_for(
-        lambda: dropdown_option_element.get_attribute("title")
-        == '',
-        lambda: '`title` is {}, expected {}'.format(
-            dropdown_option_element.get_attribute("title"),
-            '',
+        lambda: dropdown_option_element.get_attribute("title") == "",
+        lambda: "`title` is {}, expected {}".format(
+            dropdown_option_element.get_attribute("title"), "",
         ),
     )
 
     dropdown_title_input.send_keys("The Big Apple")
 
     wait_for(
-        lambda: dropdown_option_element.get_attribute("title")
-        == "The Big Apple",
-        lambda: '`title` is {}, expected {}'.format(
-            dropdown_option_element.get_attribute("title"),
-            "The Big Apple",
+        lambda: dropdown_option_element.get_attribute("title") == "The Big Apple",
+        lambda: "`title` is {}, expected {}".format(
+            dropdown_option_element.get_attribute("title"), "The Big Apple",
         ),
     )
 
@@ -71,21 +71,17 @@ def test_ddot001_option_title(dash_dcc, multi):
     dropdown_title_input.send_keys("Gotham City?")
 
     wait_for(
-        lambda: dropdown_option_element.get_attribute("title")
-        == "Gotham City?",
-        lambda: '`title` is {}, expected {}'.format(
-            dropdown_option_element.get_attribute("title"),
-            "Gotham City?",
+        lambda: dropdown_option_element.get_attribute("title") == "Gotham City?",
+        lambda: "`title` is {}, expected {}".format(
+            dropdown_option_element.get_attribute("title"), "Gotham City?",
         ),
     )
 
     dash_dcc.clear_input(dropdown_title_input)
 
     wait_for(
-        lambda: dropdown_option_element.get_attribute("title")
-        == '',
-        lambda: '`title` is {}, expected {}'.format(
-            dropdown_option_element.get_attribute("title"),
-            '',
+        lambda: dropdown_option_element.get_attribute("title") == "",
+        lambda: "`title` is {}, expected {}".format(
+            dropdown_option_element.get_attribute("title"), "",
         ),
     )

--- a/tests/integration/dropdown/test_visibility.py
+++ b/tests/integration/dropdown/test_visibility.py
@@ -9,38 +9,37 @@ import pytest
 @pytest.mark.DCC788
 def test_ddvi001_fixed_table(dash_duo):
     app = Dash(__name__)
-    app.layout = Div([
-        Dropdown(
-            id='dropdown',
-            options=[
-                {'label': 'New York City', 'value': 'NYC'},
-                {'label': 'Montreal', 'value': 'MTL'},
-                {'label': 'San Francisco', 'value': 'SF'}
-            ],
-            value='NYC'
-        ),
-        DataTable(
-            id='table',
-            columns=[{
-                'name': x,
-                'id': x,
-                'selectable': True
-            } for x in ['a', 'b', 'c']],
-            editable=True,
-            row_deletable=True,
-            fixed_rows=dict(headers=True),
-            fixed_columns=dict(headers=True),
-            data=[{
-                'a': 'a' + str(x),
-                'b': 'b' + str(x),
-                'c': 'c' + str(x),
-            } for x in range(0, 20)]
-        )
-    ])
+    app.layout = Div(
+        [
+            Dropdown(
+                id="dropdown",
+                options=[
+                    {"label": "New York City", "value": "NYC"},
+                    {"label": "Montreal", "value": "MTL"},
+                    {"label": "San Francisco", "value": "SF"},
+                ],
+                value="NYC",
+            ),
+            DataTable(
+                id="table",
+                columns=[
+                    {"name": x, "id": x, "selectable": True} for x in ["a", "b", "c"]
+                ],
+                editable=True,
+                row_deletable=True,
+                fixed_rows=dict(headers=True),
+                fixed_columns=dict(headers=True),
+                data=[
+                    {"a": "a" + str(x), "b": "b" + str(x), "c": "c" + str(x),}
+                    for x in range(0, 20)
+                ],
+            ),
+        ]
+    )
 
     dash_duo.start_server(app)
 
     dash_duo.find_element("#dropdown").click()
-    dash_duo.wait_for_element('#dropdown .Select-menu-outer')
+    dash_duo.wait_for_element("#dropdown .Select-menu-outer")
 
-    dash_duo.percy_snapshot('dcc.Dropdown dropdown overlaps table fixed rows/columns')
+    dash_duo.percy_snapshot("dcc.Dropdown dropdown overlaps table fixed rows/columns")

--- a/tests/integration/dropdown/test_visibility.py
+++ b/tests/integration/dropdown/test_visibility.py
@@ -30,7 +30,7 @@ def test_ddvi001_fixed_table(dash_duo):
                 fixed_rows=dict(headers=True),
                 fixed_columns=dict(headers=True),
                 data=[
-                    {"a": "a" + str(x), "b": "b" + str(x), "c": "c" + str(x),}
+                    {"a": "a" + str(x), "b": "b" + str(x), "c": "c" + str(x)}
                     for x in range(0, 20)
                 ],
             ),

--- a/tests/integration/graph/test_graph_basics.py
+++ b/tests/integration/graph/test_graph_basics.py
@@ -15,7 +15,7 @@ import dash.testing.wait as wait
 def test_grbs001_graph_without_ids(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
     app.layout = html.Div(
-        [dcc.Graph(className="graph-no-id-1"), dcc.Graph(className="graph-no-id-2"),]
+        [dcc.Graph(className="graph-no-id-1"), dcc.Graph(className="graph-no-id-2")]
     )
 
     dash_dcc.start_server(app)

--- a/tests/integration/graph/test_graph_basics.py
+++ b/tests/integration/graph/test_graph_basics.py
@@ -15,10 +15,7 @@ import dash.testing.wait as wait
 def test_grbs001_graph_without_ids(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
     app.layout = html.Div(
-        [
-            dcc.Graph(className="graph-no-id-1"),
-            dcc.Graph(className="graph-no-id-2"),
-        ]
+        [dcc.Graph(className="graph-no-id-1"), dcc.Graph(className="graph-no-id-2"),]
     )
 
     dash_dcc.start_server(app)
@@ -37,9 +34,7 @@ def test_grbs002_wrapped_graph_has_no_infinite_loop(dash_dcc, is_eager):
 
     df = pd.DataFrame(np.random.randn(50, 50))
     figure = {
-        "data": [
-            {"x": df.columns, "y": df.index, "z": df.values, "type": "heatmap"}
-        ],
+        "data": [{"x": df.columns, "y": df.index, "z": df.values, "type": "heatmap"}],
         "layout": {"xaxis": {"scaleanchor": "y"}},
     }
 
@@ -95,44 +90,40 @@ def test_grbs002_wrapped_graph_has_no_infinite_loop(dash_dcc, is_eager):
 @pytest.mark.DCC672
 def test_grbs003_graph_wrapped_in_loading_component_does_not_fail(dash_dcc):
     app = dash.Dash(__name__, suppress_callback_exceptions=True)
-    app.layout = html.Div([
-        html.H1('subplot issue'),
-        dcc.Location(id='url', refresh=False),
-        dcc.Loading(id="page-content")
-    ])
+    app.layout = html.Div(
+        [
+            html.H1("subplot issue"),
+            dcc.Location(id="url", refresh=False),
+            dcc.Loading(id="page-content"),
+        ]
+    )
 
-    @app.callback(Output('page-content', 'children'), [Input('url', 'pathname')])
+    @app.callback(Output("page-content", "children"), [Input("url", "pathname")])
     def render_page(url):
         return [
             dcc.Dropdown(
-                id='my-dropdown',
+                id="my-dropdown",
                 options=[
-                    {'label': 'option 1', 'value': '1'},
-                    {'label': 'option 2', 'value': '2'}
+                    {"label": "option 1", "value": "1"},
+                    {"label": "option 2", "value": "2"},
                 ],
-                value='1'
+                value="1",
             ),
-            dcc.Graph(id='my-graph')
+            dcc.Graph(id="my-graph"),
         ]
 
-    @app.callback(Output('my-graph', 'figure'), [Input('my-dropdown', 'value')])
+    @app.callback(Output("my-graph", "figure"), [Input("my-dropdown", "value")])
     def update_graph(value):
         values = [1, 2, 3]
         ranges = [1, 2, 3]
 
         return {
-            'data': [{
-                'x': ranges,
-                'y': values,
-                'line': {
-                    'shape': 'spline'
-                }
-            }],
+            "data": [{"x": ranges, "y": values, "line": {"shape": "spline"}}],
         }
 
     dash_dcc.start_server(app)
 
-    dash_dcc.wait_for_element('#my-graph .main-svg')
+    dash_dcc.wait_for_element("#my-graph .main-svg")
 
     assert not dash_dcc.get_logs()
 
@@ -141,35 +132,31 @@ def test_grbs003_graph_wrapped_in_loading_component_does_not_fail(dash_dcc):
 def test_grbs004_graph_loading_state_updates(dash_dcc):
     lock = Lock()
     app = dash.Dash(__name__, suppress_callback_exceptions=True)
-    app.layout = html.Div([
-        html.H1(id='title', children='loading state updates'),
-        dcc.Graph(id='my-graph'),
-    ])
+    app.layout = html.Div(
+        [
+            html.H1(id="title", children="loading state updates"),
+            dcc.Graph(id="my-graph"),
+        ]
+    )
 
-    @app.callback(Output('my-graph', 'figure'), [Input('title', 'n_clicks')])
+    @app.callback(Output("my-graph", "figure"), [Input("title", "n_clicks")])
     def update_graph(n_clicks):
         values = [0, n_clicks]
         ranges = [0, n_clicks]
 
         with lock:
             return {
-                'data': [{
-                    'x': ranges,
-                    'y': values,
-                    'line': {
-                        'shape': 'spline'
-                    }
-                }],
+                "data": [{"x": ranges, "y": values, "line": {"shape": "spline"}}],
             }
 
     dash_dcc.start_server(app)
-    dash_dcc.wait_for_element('#my-graph:not([data-dash-is-loading])')
+    dash_dcc.wait_for_element("#my-graph:not([data-dash-is-loading])")
 
     with lock:
-        title = dash_dcc.wait_for_element('#title')
+        title = dash_dcc.wait_for_element("#title")
         title.click()
         dash_dcc.wait_for_element('#my-graph[data-dash-is-loading="true"]')
 
-    dash_dcc.wait_for_element('#my-graph:not([data-dash-is-loading])')
+    dash_dcc.wait_for_element("#my-graph:not([data-dash-is-loading])")
 
     assert not dash_dcc.get_logs()

--- a/tests/integration/graph/test_graph_purge.py
+++ b/tests/integration/graph/test_graph_purge.py
@@ -13,23 +13,21 @@ import dash_html_components as html
 def test_grgp001_clean_purge(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
 
-    app.layout = html.Div([
-        html.Button("toggle children", id="tog"),
-        html.Div(id="out")
-    ])
-
-    @app.callback(
-        Output("out", "children"),
-        [Input("tog", "n_clicks")]
+    app.layout = html.Div(
+        [html.Button("toggle children", id="tog"), html.Div(id="out")]
     )
+
+    @app.callback(Output("out", "children"), [Input("tog", "n_clicks")])
     def show_output(num):
         if (num or 0) % 2:
-            return dcc.Graph(figure={
-                "data": [{
-                    "type": "scatter3d", "x": [1, 2], "y": [3, 4], "z": [5, 6]
-                }],
-                "layout": {"title": {"text": "A graph!"}}
-            })
+            return dcc.Graph(
+                figure={
+                    "data": [
+                        {"type": "scatter3d", "x": [1, 2], "y": [3, 4], "z": [5, 6]}
+                    ],
+                    "layout": {"title": {"text": "A graph!"}},
+                }
+            )
         else:
             return "No graphs here!"
 
@@ -44,7 +42,7 @@ def test_grgp001_clean_purge(dash_dcc, is_eager):
     tog.click()
     dash_dcc.wait_for_text_to_equal("#out", "No graphs here!")
 
-    dash_dcc.find_element('body').send_keys(Keys.CONTROL)
+    dash_dcc.find_element("body").send_keys(Keys.CONTROL)
 
     # the error with CONTROL was happening in an animation frame loop
     # wait a little to ensure it has fired

--- a/tests/integration/graph/test_graph_responsive.py
+++ b/tests/integration/graph/test_graph_responsive.py
@@ -12,49 +12,41 @@ from utils import wait_for
 @pytest.mark.parametrize("autosize", [True, False, None])
 @pytest.mark.parametrize("height", [600, None])
 @pytest.mark.parametrize("width", [600, None])
-@pytest.mark.parametrize("is_responsive", [True, False, 'auto'])
-def test_grrs001_graph(
-    dash_dcc, responsive, autosize, height, width, is_responsive
-):
+@pytest.mark.parametrize("is_responsive", [True, False, "auto"])
+def test_grrs001_graph(dash_dcc, responsive, autosize, height, width, is_responsive):
     app = dash.Dash(__name__, eager_loading=True)
 
-    header_style = dict(
-        padding='10px', backgroundColor='yellow', flex='0 0 100px'
-    )
+    header_style = dict(padding="10px", backgroundColor="yellow", flex="0 0 100px")
 
-    graph_style = dict(padding='10px', backgroundColor='red', flex='1 0 0')
+    graph_style = dict(padding="10px", backgroundColor="red", flex="1 0 0")
 
     card_style = dict(
-        display='flex',
-        flexFlow='column',
-        backgroundColor='green',
-        padding='10px',
-        height='500px',
-        width='1000px',
+        display="flex",
+        flexFlow="column",
+        backgroundColor="green",
+        padding="10px",
+        height="500px",
+        width="1000px",
     )
 
     header = html.Div(
-        id='header',
+        id="header",
         style=header_style,
-        children=[html.Button(id='resize', children=['Resize'])],
+        children=[html.Button(id="resize", children=["Resize"])],
     )
 
     graph = html.Div(
         style=graph_style,
         children=[
             dcc.Graph(
-                id='graph',
+                id="graph",
                 responsive=is_responsive,
-                style=dict(height='100%', width='100%'),
+                style=dict(height="100%", width="100%"),
                 config=dict(responsive=responsive),
                 figure=dict(
                     layout=dict(autosize=autosize, height=height, width=width),
                     data=[
-                        dict(
-                            x=[1, 2, 3, 4],
-                            y=[5, 4, 3, 6],
-                            line=dict(shape='spline'),
-                        )
+                        dict(x=[1, 2, 3, 4], y=[5, 4, 3, 6], line=dict(shape="spline"),)
                     ],
                 ),
             )
@@ -65,27 +57,27 @@ def test_grrs001_graph(
         [
             html.Div(
                 [
-                    'responsive: {}, '.format(responsive),
-                    'autosize: {}, '.format(autosize),
-                    'height: {}, '.format(height),
-                    'width: {}, '.format(width),
-                    'is_responsive: {}'.format(is_responsive),
+                    "responsive: {}, ".format(responsive),
+                    "autosize: {}, ".format(autosize),
+                    "height: {}, ".format(height),
+                    "width: {}, ".format(width),
+                    "is_responsive: {}".format(is_responsive),
                 ]
             ),
-            html.Div(id='card', style=card_style, children=[header, graph]),
+            html.Div(id="card", style=card_style, children=[header, graph]),
         ]
     )
 
     @app.callback(
-        Output('header', 'style'),
-        [Input('resize', 'n_clicks')],
-        [State('header', 'style')],
+        Output("header", "style"),
+        [Input("resize", "n_clicks")],
+        [State("header", "style")],
     )
     def resize(n_clicks, style):
         if n_clicks is None:
             raise PreventUpdate
 
-        return dict(style, **dict(flex='0 0 200px'))
+        return dict(style, **dict(flex="0 0 200px"))
 
     dash_dcc.start_server(app)
 
@@ -95,13 +87,13 @@ def test_grrs001_graph(
     # behaves the same as responsive=false (https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js#L122)
 
     initial_responsive = is_responsive is True or (
-        is_responsive == 'auto'
+        is_responsive == "auto"
         and autosize is not False
         and (height is None or width is None)
     )
 
     resize_responsive = is_responsive is True or (
-        is_responsive == 'auto'
+        is_responsive == "auto"
         and responsive is True
         and autosize is not False
         and (height is None or width is None)
@@ -125,29 +117,21 @@ def test_grrs001_graph(
 
     wait_for(
         # 500px card minus (100px header + 20px padding) minus (20px padding on container) -> 360px left
-        lambda: dash_dcc.wait_for_element('#graph svg.main-svg').size.get(
-            'height', -1
-        )
+        lambda: dash_dcc.wait_for_element("#graph svg.main-svg").size.get("height", -1)
         == initial_height,
-        lambda: 'initial graph height {}, expected {}'.format(
-            dash_dcc.wait_for_element('#graph svg.main-svg').size.get(
-                'height', -1
-            ),
+        lambda: "initial graph height {}, expected {}".format(
+            dash_dcc.wait_for_element("#graph svg.main-svg").size.get("height", -1),
             initial_height,
         ),
     )
-    dash_dcc.wait_for_element('#resize').click()
+    dash_dcc.wait_for_element("#resize").click()
 
     wait_for(
         # 500px card minus (200px header + 20px padding) minus (20px padding on container) -> 260px left
-        lambda: dash_dcc.wait_for_element('#graph svg.main-svg').size.get(
-            'height', -1
-        )
+        lambda: dash_dcc.wait_for_element("#graph svg.main-svg").size.get("height", -1)
         == resize_height,
-        lambda: 'resized graph height {}, expected {}'.format(
-            dash_dcc.wait_for_element('#graph svg.main-svg').size.get(
-                'height', -1
-            ),
+        lambda: "resized graph height {}, expected {}".format(
+            dash_dcc.wait_for_element("#graph svg.main-svg").size.get("height", -1),
             resize_height,
         ),
     )

--- a/tests/integration/graph/test_graph_varia.py
+++ b/tests/integration/graph/test_graph_varia.py
@@ -14,15 +14,13 @@ from selenium.webdriver.support import expected_conditions as EC
 
 def findSyncPlotlyJs(scripts):
     for script in scripts:
-        if "dash_core_components/plotly-" in script.get_attribute('src'):
+        if "dash_core_components/plotly-" in script.get_attribute("src"):
             return script
 
 
 def findAsyncPlotlyJs(scripts):
     for script in scripts:
-        if "dash_core_components/async-plotlyjs" in script.get_attribute(
-            'src'
-        ):
+        if "dash_core_components/async-plotlyjs" in script.get_attribute("src"):
             return script
 
 
@@ -31,9 +29,7 @@ def test_candlestick(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
     app.layout = html.Div(
         [
-            html.Button(
-                id="button", children="Update Candlestick", n_clicks=0
-            ),
+            html.Button(id="button", children="Update Candlestick", n_clicks=0),
             dcc.Graph(id="graph"),
         ]
     )
@@ -62,14 +58,20 @@ def test_candlestick(dash_dcc, is_eager):
         EC.visibility_of_element_located((By.CSS_SELECTOR, "#graph .main-svg"))
     )
 
-    dash_dcc.percy_snapshot("candlestick - initial ({})".format("eager" if is_eager else "lazy"))
+    dash_dcc.percy_snapshot(
+        "candlestick - initial ({})".format("eager" if is_eager else "lazy")
+    )
     button.click()
     time.sleep(1)
-    dash_dcc.percy_snapshot("candlestick - 1 click ({})".format("eager" if is_eager else "lazy"))
+    dash_dcc.percy_snapshot(
+        "candlestick - 1 click ({})".format("eager" if is_eager else "lazy")
+    )
 
     button.click()
     time.sleep(1)
-    dash_dcc.percy_snapshot("candlestick - 2 click ({})".format("eager" if is_eager else "lazy"))
+    dash_dcc.percy_snapshot(
+        "candlestick - 2 click ({})".format("eager" if is_eager else "lazy")
+    )
 
 
 @pytest.mark.parametrize("is_eager", [True, False])
@@ -81,12 +83,7 @@ def test_graphs_with_different_figures(dash_dcc, is_eager):
                 id="example-graph",
                 figure={
                     "data": [
-                        {
-                            "x": [1, 2, 3],
-                            "y": [4, 1, 2],
-                            "type": "bar",
-                            "name": "SF",
-                        },
+                        {"x": [1, 2, 3], "y": [4, 1, 2], "type": "bar", "name": "SF",},
                         {
                             "x": [1, 2, 3],
                             "y": [2, 4, 5],
@@ -123,8 +120,7 @@ def test_graphs_with_different_figures(dash_dcc, is_eager):
     )
 
     @app.callback(
-        Output("restyle-data", "children"),
-        [Input("example-graph", "restyleData")],
+        Output("restyle-data", "children"), [Input("example-graph", "restyleData")],
     )
     def show_restyle_data(data):
         if data is None:  # ignore initial
@@ -132,13 +128,10 @@ def test_graphs_with_different_figures(dash_dcc, is_eager):
         return json.dumps(data)
 
     @app.callback(
-        Output("relayout-data", "children"),
-        [Input("example-graph", "relayoutData")],
+        Output("relayout-data", "children"), [Input("example-graph", "relayoutData")],
     )
     def show_relayout_data(data):
-        if (
-            data is None or "autosize" in data
-        ):  # ignore initial & auto width
+        if data is None or "autosize" in data:  # ignore initial & auto width
             return ""
         return json.dumps(data)
 
@@ -155,17 +148,15 @@ def test_graphs_with_different_figures(dash_dcc, is_eager):
     )
 
     # move snapshot after click, so it's more stable with the wait
-    dash_dcc.percy_snapshot("2 graphs with different figures ({})".format("eager" if is_eager else "lazy"))
+    dash_dcc.percy_snapshot(
+        "2 graphs with different figures ({})".format("eager" if is_eager else "lazy")
+    )
 
     # and test relayoutData while we're at it
-    autoscale = dash_dcc.driver.find_element_by_css_selector(
-        "#example-graph .ewdrag"
-    )
+    autoscale = dash_dcc.driver.find_element_by_css_selector("#example-graph .ewdrag")
     autoscale.click()
     autoscale.click()
-    dash_dcc.wait_for_text_to_equal(
-        "#relayout-data", '{"xaxis.autorange": true}'
-    )
+    dash_dcc.wait_for_text_to_equal("#relayout-data", '{"xaxis.autorange": true}')
 
 
 @pytest.mark.parametrize("is_eager", [True, False])
@@ -177,11 +168,7 @@ def test_empty_graph(dash_dcc, is_eager):
             html.Button(id="click", children="Click me"),
             dcc.Graph(
                 id="graph",
-                figure={
-                    "data": [
-                        dict(x=[1, 2, 3], y=[1, 2, 3], type="scatter")
-                    ]
-                },
+                figure={"data": [dict(x=[1, 2, 3], y=[1, 2, 3], type="scatter")]},
             ),
         ]
     )
@@ -200,7 +187,9 @@ def test_empty_graph(dash_dcc, is_eager):
     button = dash_dcc.wait_for_element("#click")
     button.click()
     time.sleep(2)  # Wait for graph to re-render
-    dash_dcc.percy_snapshot("render-empty-graph ({})".format("eager" if is_eager else "lazy"))
+    dash_dcc.percy_snapshot(
+        "render-empty-graph ({})".format("eager" if is_eager else "lazy")
+    )
 
 
 @pytest.mark.parametrize("is_eager", [True, False])
@@ -349,42 +338,17 @@ def test_graph_extend_trace(dash_dcc, is_eager):
             ),
         ]
     )
-    dash_dcc.wait_for_text_to_equal(
-        "#output_trace_will_extend_selectively", comparison
-    )
+    dash_dcc.wait_for_text_to_equal("#output_trace_will_extend_selectively", comparison)
 
     comparison = json.dumps(
-        [
-            dict(
-                x=[3, 4, 5, 6, 7, 8, 9],
-                y=[0.5, 0, 0.1, 0.2, 0.3, 0.4, 0.5],
-            )
-        ]
+        [dict(x=[3, 4, 5, 6, 7, 8, 9], y=[0.5, 0, 0.1, 0.2, 0.3, 0.4, 0.5],)]
     )
     dash_dcc.wait_for_text_to_equal(
         "#output_trace_will_extend_with_max_points", comparison
     )
 
     comparison = json.dumps(
-        [
-            dict(
-                y=[
-                    0,
-                    0,
-                    0,
-                    0.1,
-                    0.2,
-                    0.3,
-                    0.4,
-                    0.5,
-                    0.1,
-                    0.2,
-                    0.3,
-                    0.4,
-                    0.5,
-                ]
-            )
-        ]
+        [dict(y=[0, 0, 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.1, 0.2, 0.3, 0.4, 0.5,])]
     )
     dash_dcc.wait_for_text_to_equal(
         "#output_trace_will_allow_repeated_extend", comparison
@@ -465,9 +429,7 @@ def test_unmounted_graph_resize(dash_dcc, is_eager):
         dash_dcc.wait_for_element("#eg-graph-1")
     except Exception as e:
         print(
-            dash_dcc.wait_for_element(
-                "#_dash-app-content"
-            ).get_attribute("innerHTML")
+            dash_dcc.wait_for_element("#_dash-app-content").get_attribute("innerHTML")
         )
         raise e
 
@@ -489,18 +451,14 @@ def test_unmounted_graph_resize(dash_dcc, is_eager):
         raise Exception("browser error logged during test", entry)
 
     # set back to original size
-    dash_dcc.driver.set_window_size(
-        window_size["width"], window_size["height"]
-    )
+    dash_dcc.driver.set_window_size(window_size["width"], window_size["height"])
 
 
 def test_external_plotlyjs_prevents_lazy(dash_dcc):
     app = dash.Dash(
         __name__,
         eager_loading=False,
-        external_scripts=[
-            'https://unpkg.com/plotly.js/dist/plotly.min.js'
-        ]
+        external_scripts=["https://unpkg.com/plotly.js/dist/plotly.min.js"],
     )
 
     app.layout = html.Div(id="div", children=[html.Button(id="btn")])

--- a/tests/integration/graph/test_graph_varia.py
+++ b/tests/integration/graph/test_graph_varia.py
@@ -83,7 +83,7 @@ def test_graphs_with_different_figures(dash_dcc, is_eager):
                 id="example-graph",
                 figure={
                     "data": [
-                        {"x": [1, 2, 3], "y": [4, 1, 2], "type": "bar", "name": "SF",},
+                        {"x": [1, 2, 3], "y": [4, 1, 2], "type": "bar", "name": "SF"},
                         {
                             "x": [1, 2, 3],
                             "y": [2, 4, 5],
@@ -348,7 +348,7 @@ def test_graph_extend_trace(dash_dcc, is_eager):
     )
 
     comparison = json.dumps(
-        [dict(y=[0, 0, 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.1, 0.2, 0.3, 0.4, 0.5,])]
+        [dict(y=[0, 0, 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.1, 0.2, 0.3, 0.4, 0.5])]
     )
     dash_dcc.wait_for_text_to_equal(
         "#output_trace_will_allow_repeated_extend", comparison

--- a/tests/integration/input/test_input_types.py
+++ b/tests/integration/input/test_input_types.py
@@ -25,9 +25,7 @@ def test_intp001_all_types(dash_dcc):
     app = dash.Dash(__name__)
     app.layout = html.Div(
         [
-            dcc.Input(
-                id=input_id(_), type=_, placeholder="input type {}".format(_)
-            )
+            dcc.Input(id=input_id(_), type=_, placeholder="input type {}".format(_))
             for _ in ALLOWING_TYPES
         ]
         + [html.Div(id="output")]
@@ -43,8 +41,7 @@ def test_intp001_all_types(dash_dcc):
     dash_dcc.start_server(app)
 
     assert (
-        dash_dcc.find_element("#input_hidden").get_attribute("type")
-        == "hidden"
+        dash_dcc.find_element("#input_hidden").get_attribute("type") == "hidden"
     ), "hidden input element should present with hidden type"
 
     dash_dcc.percy_snapshot("intp001 - init state")

--- a/tests/integration/input/test_number_input.py
+++ b/tests/integration/input/test_number_input.py
@@ -16,9 +16,7 @@ def test_inni001_invalid_numbers(ninput_app, dash_dcc):
         for debounce in ("false", "true"):
 
             elem = dash_dcc.find_element("#input_{}".format(debounce))
-            assert not elem.get_attribute(
-                "value"
-            ), "input should have no initial value"
+            assert not elem.get_attribute("value"), "input should have no initial value"
 
             # onblur
             elem.send_keys(invalid_number)
@@ -61,15 +59,11 @@ def test_inni003_invalid_numbers_range(dash_dcc, input_range_app):
 
     for invalid_number in ("0.0", "12", "10e10"):
         elem_range.send_keys(invalid_number)
-        dash_dcc.wait_for_text_to_equal(
-            "#out", ""
-        ), "invalid value should return none"
+        dash_dcc.wait_for_text_to_equal("#out", ""), "invalid value should return none"
         dash_dcc.clear_input(elem_range)
 
     elem_range.send_keys("-13")
-    dash_dcc.wait_for_text_to_equal(
-        "#out", ""
-    ), "invalid value should return none"
+    dash_dcc.wait_for_text_to_equal("#out", ""), "invalid value should return none"
 
     time.sleep(0.5)
     dash_dcc.percy_snapshot("inni003 - number out of range")

--- a/tests/integration/link/test_absolute_path.py
+++ b/tests/integration/link/test_absolute_path.py
@@ -12,16 +12,17 @@ def test_lipa001_path(dash_dcc):
         [
             dcc.Link("Relative Path", id="link1", href="google.com"),
             dcc.Location(id="url", refresh=False),
-            html.Div(id="content")
+            html.Div(id="content"),
         ]
     )
+
     @app.callback(Output("content", "children"), [Input("url", "pathname")])
     def display_children(children):
         return children
 
     dash_dcc.start_server(app)
 
-    dash_dcc.wait_for_element('#link1').click()
+    dash_dcc.wait_for_element("#link1").click()
 
     dash_dcc.wait_for_text_to_equal("#content", "/google.com")
 
@@ -31,18 +32,23 @@ def test_lipa002_path(dash_dcc):
     app = dash.Dash(__name__)
     app.layout = html.Div(
         [
-            dcc.Link(children='Absolute Path', id="link1", href="https://google.com", refresh=True),
-            dcc.Location(id="url", refresh=False)
+            dcc.Link(
+                children="Absolute Path",
+                id="link1",
+                href="https://google.com",
+                refresh=True,
+            ),
+            dcc.Location(id="url", refresh=False),
         ]
     )
     dash_dcc.start_server(app)
 
-    dash_dcc.wait_for_element('#link1').click()
+    dash_dcc.wait_for_element("#link1").click()
 
     location = dash_dcc.driver.execute_script(
-        '''
+        """
         return window.location.href
-        '''
+        """
     )
 
-    assert location == 'https://www.google.com/'
+    assert location == "https://www.google.com/"

--- a/tests/integration/link/test_link_children.py
+++ b/tests/integration/link/test_link_children.py
@@ -12,7 +12,7 @@ def test_lich001_default(dash_dcc):
         [
             dcc.Link(id="link1", href="/page-1"),
             dcc.Location(id="url", refresh=False),
-            html.Div(id="content")
+            html.Div(id="content"),
         ]
     )
     dash_dcc.start_server(app)
@@ -25,11 +25,12 @@ def test_lich002_children(dash_dcc):
     app = dash.Dash(__name__)
     app.layout = html.Div(
         [
-            dcc.Link(children='test children', id="link1", href="/page-1"),
+            dcc.Link(children="test children", id="link1", href="/page-1"),
             dcc.Location(id="url", refresh=False),
-            html.Div(id="content")
+            html.Div(id="content"),
         ]
     )
+
     @app.callback(Output("content", "children"), [Input("link1", "children")])
     def display_children(children):
         return children

--- a/tests/integration/link/test_link_event.py
+++ b/tests/integration/link/test_link_event.py
@@ -10,7 +10,7 @@ def test_link001_event(dash_dcc):
         [
             dcc.Link("Page 1", id="link1", href="/page-1"),
             dcc.Location(id="url", refresh=False),
-            html.Div(id='content'),
+            html.Div(id="content"),
         ]
     )
 
@@ -25,7 +25,7 @@ def test_link001_event(dash_dcc):
 
     dash_dcc.start_server(app)
     dash_dcc.driver.execute_script(
-        '''
+        """
         window.addEventListener('_dashprivate_pushstate', function() {
             window._test_link_event_counter = (window._test_link_event_counter || 0) + 1;
         });
@@ -33,25 +33,25 @@ def test_link001_event(dash_dcc):
         window.addEventListener('_dashprivate_historychange', function() {
             window._test_history_event_counter = (window._test_history_event_counter || 0) + 1;
         });
-    '''
+    """
     )
 
     dash_dcc.wait_for_element_by_id("div0")
 
-    dash_dcc.find_element('#link1').click()
+    dash_dcc.find_element("#link1").click()
 
     dash_dcc.wait_for_element_by_id("div1")
 
     link_counter = dash_dcc.driver.execute_script(
-        '''
+        """
         return window._test_link_event_counter;
-    '''
+    """
     )
 
     history_counter = dash_dcc.driver.execute_script(
-        '''
+        """
         return window._test_history_event_counter;
-    '''
+    """
     )
 
     assert link_counter == 1

--- a/tests/integration/link/test_title_prop.py
+++ b/tests/integration/link/test_title_prop.py
@@ -10,17 +10,20 @@ def test_liti001_prop(dash_dcc):
     app = dash.Dash(__name__)
     app.layout = html.Div(
         [
-            dcc.Link("page 1", id="link1", href="/page-1", title="This is a test title!"),
+            dcc.Link(
+                "page 1", id="link1", href="/page-1", title="This is a test title!"
+            ),
             dcc.Location(id="url", refresh=False),
-            html.Div(id="content")
+            html.Div(id="content"),
         ]
     )
+
     @app.callback(Output("content", "children"), [Input("link1", "title")])
     def display_title(title):
         return title
 
     dash_dcc.start_server(app)
 
-    title_exists = dash_dcc.find_element('#link1').get_attribute('title')
+    title_exists = dash_dcc.find_element("#link1").get_attribute("title")
 
     assert title_exists == "This is a test title!"

--- a/tests/integration/location/test_location_callback.py
+++ b/tests/integration/location/test_location_callback.py
@@ -8,19 +8,18 @@ import dash_html_components as html
 @pytest.mark.DCC774
 def test_loca001_callbacks(dash_dcc):
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        dcc.Location(
-            id='location',
-            refresh=False
-        ),
-        html.A('Anchor Link 1', href='#div'),
-        html.Div(id='div')
-    ])
+    app.layout = html.Div(
+        [
+            dcc.Location(id="location", refresh=False),
+            html.A("Anchor Link 1", href="#div"),
+            html.Div(id="div"),
+        ]
+    )
 
-    @app.callback(Output('div', 'children'), [Input('location', 'pathname')])
+    @app.callback(Output("div", "children"), [Input("location", "pathname")])
     def update_path(path):
         return path
 
     dash_dcc.start_server(app)
 
-    dash_dcc.wait_for_text_to_equal('#div', '/')
+    dash_dcc.wait_for_text_to_equal("#div", "/")

--- a/tests/integration/markdown/test_markdown.py
+++ b/tests/integration/markdown/test_markdown.py
@@ -8,11 +8,11 @@ def test_mkdw001_img(dash_dcc):
 
     app.layout = html.Div(
         [
-            html.Div('Markdown img'),
+            html.Div("Markdown img"),
             dcc.Markdown(
                 ['<img src="assets/image.png" />'], dangerously_allow_html=True
             ),
-            html.Div('Markdown img - requires dangerously_allow_html'),
+            html.Div("Markdown img - requires dangerously_allow_html"),
             dcc.Markdown(['<img src="assets/image.png" />']),
         ]
     )
@@ -26,65 +26,65 @@ def test_mkdw002_dcclink(dash_dcc):
 
     app.layout = html.Div(
         [
-            html.Div(['Markdown link']),
-            dcc.Markdown(['[Title](title_crumb)']),
-            html.Div(['Markdown dccLink']),
+            html.Div(["Markdown link"]),
+            dcc.Markdown(["[Title](title_crumb)"]),
+            html.Div(["Markdown dccLink"]),
             dcc.Markdown(
                 ['<dccLink href="title_crumb" children="Title" />'],
                 dangerously_allow_html=True,
             ),
-            html.Div(['Markdown dccLink - explicit children']),
+            html.Div(["Markdown dccLink - explicit children"]),
             dcc.Markdown(
                 [
-                    '''
+                    """
             <dccLink href="title_crumb">
                 Title
             </dccLink>
-        '''
+        """
                 ],
                 dangerously_allow_html=True,
             ),
-            html.Div('Markdown dccLink = inlined'),
+            html.Div("Markdown dccLink = inlined"),
             dcc.Markdown(
                 [
                     'This is an inlined <dccLink href="title_crumb" children="Title" /> with text on both sides'
                 ],
                 dangerously_allow_html=True,
             ),
-            html.Div('Markdown dccLink - nested image'),
+            html.Div("Markdown dccLink - nested image"),
             dcc.Markdown(
                 [
-                    '''
+                    """
             <dccLink href="title_crumb">
                 <img src="assets/image.png" />
             </dccLink>
-        '''
+        """
                 ],
                 dangerously_allow_html=True,
             ),
-            html.Div('Markdown dccLink - nested markdown'),
+            html.Div("Markdown dccLink - nested markdown"),
             dcc.Markdown(
                 [
-                    '''
+                    """
             <dccLink href="title_crumb">
                 <dccMarkdown children="## Title" />
             </dccLink>
-        '''
+        """
                 ],
                 dangerously_allow_html=True,
             ),
-            html.Div('Markdown dccLink - nested markdown image'),
+            html.Div("Markdown dccLink - nested markdown image"),
             dcc.Markdown(
                 [
-                    '''
+                    """
             <dccLink href="title_crumb">
                 <dccMarkdown children="![Image](assets/image.png)" />
             </dccLink>
-        '''
+        """
                 ],
                 dangerously_allow_html=True,
             ),
-            html.Div('Markdown dccLink - requires dangerously_allow_html'),
+            html.Div("Markdown dccLink - requires dangerously_allow_html"),
             dcc.Markdown(['<dccLink href="title_crumb" children="Title" />']),
         ]
     )

--- a/tests/integration/misc/conftest.py
+++ b/tests/integration/misc/conftest.py
@@ -48,9 +48,7 @@ def platter_app():
                     ),
                     dcc.Tab(
                         label="Tab three",
-                        children=[
-                            html.Div([html.H1("This is the content in tab 3")])
-                        ],
+                        children=[html.Div([html.H1("This is the content in tab 3")])],
                     ),
                 ],
                 style={"fontFamily": "system-ui"},
@@ -76,9 +74,7 @@ def platter_app():
                     ),
                     dcc.Tab(
                         label="Tab three",
-                        children=[
-                            html.Div([html.H1("This is the content in tab 3")])
-                        ],
+                        children=[html.Div([html.H1("This is the content in tab 3")])],
                     ),
                 ],
             ),
@@ -94,18 +90,14 @@ def platter_app():
             dcc.Input(value="", placeholder="type here", id="textinput"),
             html.Label("Disabled Text Input"),
             dcc.Input(
-                value="disabled",
-                type="text",
-                id="disabled-textinput",
-                disabled=True,
+                value="disabled", type="text", id="disabled-textinput", disabled=True,
             ),
             html.Label("Slider"),
             dcc.Slider(
                 min=0,
                 max=9,
                 marks={
-                    i: "Label {}".format(i) if i == 1 else str(i)
-                    for i in range(1, 6)
+                    i: "Label {}".format(i) if i == 1 else str(i) for i in range(1, 6)
                 },
                 value=5,
             ),
@@ -183,9 +175,7 @@ def platter_app():
                 ]
             ),
             html.Label("TextArea"),
-            dcc.Textarea(
-                placeholder="Enter a value... 北京", style={"width": "100%"}
-            ),
+            dcc.Textarea(placeholder="Enter a value... 北京", style={"width": "100%"}),
             html.Label("Markdown"),
             dcc.Markdown(
                 """

--- a/tests/integration/misc/test_markdown_highlight.py
+++ b/tests/integration/misc/test_markdown_highlight.py
@@ -6,10 +6,10 @@ import dash_core_components as dcc
 import dash_html_components as html
 
 
-md_text = '''```python
+md_text = """```python
 import dash
 print('hello, world!')
-```'''
+```"""
 
 
 def test_msmh001_no_window_variable(dash_dcc):
@@ -17,25 +17,19 @@ def test_msmh001_no_window_variable(dash_dcc):
     app.layout = html.Div(dcc.Markdown(md_text))
     dash_dcc.start_server(app)
 
-    dash_dcc.wait_for_element('code')
+    dash_dcc.wait_for_element("code")
 
-    window_hljs = dash_dcc.driver.execute_script('return window.hljs')
+    window_hljs = dash_dcc.driver.execute_script("return window.hljs")
     assert window_hljs is None
 
 
 def test_msmh002_window_override(dash_dcc):
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        html.Button(id='md-trigger'),
-        html.Div(id='md-container')
-    ])
+    app.layout = html.Div([html.Button(id="md-trigger"), html.Div(id="md-container")])
 
     # we can't run the script below until after the page has loaded,
     # so we need to trigger a rerender of the markdown component
-    @app.callback(
-        Output('md-container', 'children'),
-        [Input('md-trigger', 'n_clicks')]
-    )
+    @app.callback(Output("md-container", "children"), [Input("md-trigger", "n_clicks")])
     def trigger_md_rerender(nclicks):
         if nclicks is not None and nclicks > 0:
             return dcc.Markdown(md_text)
@@ -43,8 +37,10 @@ def test_msmh002_window_override(dash_dcc):
 
     dash_dcc.start_server(app)
 
-    dash_dcc.driver.execute_script('window.hljs = {highlightBlock: (block) => {block.innerHTML="hljs override"}};')
+    dash_dcc.driver.execute_script(
+        'window.hljs = {highlightBlock: (block) => {block.innerHTML="hljs override"}};'
+    )
 
-    dash_dcc.find_element('#md-trigger').click()
-    dash_dcc.wait_for_text_to_equal('#md-container code', 'hljs override')
-    dash_dcc.percy_snapshot('md_code_highlight_override')
+    dash_dcc.find_element("#md-trigger").click()
+    dash_dcc.wait_for_text_to_equal("#md-container code", "hljs override")
+    dash_dcc.percy_snapshot("md_code_highlight_override")

--- a/tests/integration/misc/test_persistence.py
+++ b/tests/integration/misc/test_persistence.py
@@ -127,9 +127,7 @@ def test_msps001_basic_persistence(dash_dcc):
     dash_dcc.find_element("#checklist label:last-child input").click()  # 🚀
 
     dash_dcc.select_date_range("datepickerrange", day_range=(4,))
-    dash_dcc.select_date_range(
-        "datepickerrange", day_range=(14,), start_first=False
-    )
+    dash_dcc.select_date_range("datepickerrange", day_range=(14,), start_first=False)
 
     dash_dcc.find_element("#datepickersingle input").click()
     dash_dcc.select_date_single("datepickersingle", day="20")

--- a/tests/integration/misc/test_platter.py
+++ b/tests/integration/misc/test_platter.py
@@ -46,9 +46,7 @@ def test_mspl001_dcc_components_platter(platter_app, dash_dcc):
     )
     reset_input(dt_input_1)
 
-    dt_input_2 = dash_dcc.find_element(
-        "#dt-single-no-date-value-init-month #date"
-    )
+    dt_input_2 = dash_dcc.find_element("#dt-single-no-date-value-init-month #date")
     dash_dcc.find_element("label").click()
     dt_input_2.click()
     dash_dcc.percy_snapshot(
@@ -67,9 +65,7 @@ def test_mspl001_dcc_components_platter(platter_app, dash_dcc):
     )
     reset_input(dt_input_3)
 
-    dt_input_4 = dash_dcc.find_element(
-        "#dt-range-no-date-values-init-month #endDate"
-    )
+    dt_input_4 = dash_dcc.find_element("#dt-range-no-date-values-init-month #endDate")
     dash_dcc.find_element("label").click()
     dt_input_4.click()
     dash_dcc.percy_snapshot(

--- a/tests/integration/sliders/test_sliders.py
+++ b/tests/integration/sliders/test_sliders.py
@@ -6,17 +6,19 @@ import dash_core_components as dcc
 
 def test_slsl001_always_visible_slider(dash_dcc):
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        dcc.Slider(
-            id="slider",
-            min=0,
-            max=20,
-            step=1,
-            value=5,
-            tooltip={"always_visible": True}
-        ),
-        html.Div(id="out")
-    ])
+    app.layout = html.Div(
+        [
+            dcc.Slider(
+                id="slider",
+                min=0,
+                max=20,
+                step=1,
+                value=5,
+                tooltip={"always_visible": True},
+            ),
+            html.Div(id="out"),
+        ]
+    )
 
     @app.callback(Output("out", "children"), [Input("slider", "value")])
     def update_output(value):
@@ -34,17 +36,20 @@ def test_slsl001_always_visible_slider(dash_dcc):
 
 def test_slsl002_always_visible_rangeslider(dash_dcc):
     app = dash.Dash(__name__)
-    app.layout = html.Div(style={'width': '400px'}, children=[
-        dcc.RangeSlider(
-            id="rangeslider",
-            min=0,
-            max=20,
-            step=1,
-            value=[5, 15],
-            tooltip={"always_visible": True}
-        ),
-        html.Div(id="out")
-    ])
+    app.layout = html.Div(
+        style={"width": "400px"},
+        children=[
+            dcc.RangeSlider(
+                id="rangeslider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+                tooltip={"always_visible": True},
+            ),
+            html.Div(id="out"),
+        ],
+    )
 
     @app.callback(Output("out", "children"), [Input("rangeslider", "value")])
     def update_output(rng):
@@ -63,30 +68,30 @@ def test_slsl002_always_visible_rangeslider(dash_dcc):
 def test_slsl003_out_of_range_marks_slider(dash_dcc):
 
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        dcc.Slider(
-            min=0,
-            max=5,
-            marks={i: 'Label {}'.format(i) for i in range(-1, 10)}
-        )
-    ])
+    app.layout = html.Div(
+        [
+            dcc.Slider(
+                min=0, max=5, marks={i: "Label {}".format(i) for i in range(-1, 10)}
+            )
+        ]
+    )
 
     dash_dcc.start_server(app)
 
-    assert len(dash_dcc.find_elements('span.rc-slider-mark-text')) == 6
+    assert len(dash_dcc.find_elements("span.rc-slider-mark-text")) == 6
 
 
 def test_slsl004_out_of_range_marks_rangeslider(dash_dcc):
 
     app = dash.Dash(__name__)
-    app.layout = html.Div([
-        dcc.RangeSlider(
-            min=0,
-            max=5,
-            marks={i: 'Label {}'.format(i) for i in range(-1, 10)}
-        )
-    ])
+    app.layout = html.Div(
+        [
+            dcc.RangeSlider(
+                min=0, max=5, marks={i: "Label {}".format(i) for i in range(-1, 10)}
+            )
+        ]
+    )
 
     dash_dcc.start_server(app)
 
-    assert len(dash_dcc.find_elements('span.rc-slider-mark-text')) == 6
+    assert len(dash_dcc.find_elements("span.rc-slider-mark-text")) == 6

--- a/tests/integration/store/conftest.py
+++ b/tests/integration/store/conftest.py
@@ -50,7 +50,7 @@ def store_app():
         return True, True, True
 
     @app.callback(
-        [Output("memory", "data"), Output("local", "data"), Output("session", "data"),],
+        [Output("memory", "data"), Output("local", "data"), Output("session", "data")],
         [Input("btn", "n_clicks")],
     )
     def on_click(n_clicks):

--- a/tests/integration/store/conftest.py
+++ b/tests/integration/store/conftest.py
@@ -50,11 +50,7 @@ def store_app():
         return True, True, True
 
     @app.callback(
-        [
-            Output("memory", "data"),
-            Output("local", "data"),
-            Output("session", "data"),
-        ],
+        [Output("memory", "data"), Output("local", "data"), Output("session", "data"),],
         [Input("btn", "n_clicks")],
     )
     def on_click(n_clicks):
@@ -68,6 +64,7 @@ def store_app():
 @pytest.fixture(scope="session")
 def csv_5mb():
     import mimesis
+
     buf, chunks = None, []
     limit = 5 * 1024 * 1024
     while sys.getsizeof(buf) <= limit:
@@ -79,6 +76,6 @@ def csv_5mb():
             )
         )
         chunks.append(chunk)
-        buf = ''.join(chunks)
+        buf = "".join(chunks)
 
-    yield buf[len(chunk):limit]
+    yield buf[len(chunk) : limit]

--- a/tests/integration/store/test_component_props.py
+++ b/tests/integration/store/test_component_props.py
@@ -158,7 +158,7 @@ def test_stcp004_remount_store_component(dash_dcc):
         return True, True, True
 
     @app.callback(
-        [Output("memory", "data"), Output("local", "data"), Output("session", "data"),],
+        [Output("memory", "data"), Output("local", "data"), Output("session", "data")],
         [Input("btn", "n_clicks")],
     )
     def on_click(n_clicks):

--- a/tests/integration/store/test_component_props.py
+++ b/tests/integration/store/test_component_props.py
@@ -40,8 +40,7 @@ def test_stcp002_modified_ts(store_app, dash_dcc):
     )
 
     @app.callback(
-        Output("initial-storage", "data"),
-        [Input("set-init-storage", "n_clicks")],
+        Output("initial-storage", "data"), [Input("set-init-storage", "n_clicks")],
     )
     def on_init(n_clicks):
         if n_clicks is None:
@@ -74,13 +73,31 @@ def test_stcp002_modified_ts(store_app, dash_dcc):
 
 def test_stcp003_initial_falsy(dash_dcc):
     app = dash.Dash(__name__)
-    app.layout = html.Div([html.Div([
-        storage_type,
-        dcc.Store(storage_type=storage_type, id="zero-" + storage_type, data=0),
-        dcc.Store(storage_type=storage_type, id="false-" + storage_type, data=False),
-        dcc.Store(storage_type=storage_type, id="null-" + storage_type, data=None),
-        dcc.Store(storage_type=storage_type, id="empty-" + storage_type, data=""),
-    ]) for storage_type in ("memory", "local", "session")], id="content")
+    app.layout = html.Div(
+        [
+            html.Div(
+                [
+                    storage_type,
+                    dcc.Store(
+                        storage_type=storage_type, id="zero-" + storage_type, data=0
+                    ),
+                    dcc.Store(
+                        storage_type=storage_type,
+                        id="false-" + storage_type,
+                        data=False,
+                    ),
+                    dcc.Store(
+                        storage_type=storage_type, id="null-" + storage_type, data=None
+                    ),
+                    dcc.Store(
+                        storage_type=storage_type, id="empty-" + storage_type, data=""
+                    ),
+                ]
+            )
+            for storage_type in ("memory", "local", "session")
+        ],
+        id="content",
+    )
 
     dash_dcc.start_server(app)
     dash_dcc.wait_for_text_to_equal("#content", "memory\nlocal\nsession")
@@ -120,7 +137,7 @@ def test_stcp004_remount_store_component(dash_dcc):
         [
             Input("memory", "modified_timestamp"),
             Input("local", "modified_timestamp"),
-            Input("session", "modified_timestamp")
+            Input("session", "modified_timestamp"),
         ],
         [State("memory", "data"), State("local", "data"), State("session", "data")],
     )
@@ -141,11 +158,7 @@ def test_stcp004_remount_store_component(dash_dcc):
         return True, True, True
 
     @app.callback(
-        [
-            Output("memory", "data"),
-            Output("local", "data"),
-            Output("session", "data"),
-        ],
+        [Output("memory", "data"), Output("local", "data"), Output("session", "data"),],
         [Input("btn", "n_clicks")],
     )
     def on_click(n_clicks):
@@ -157,14 +170,12 @@ def test_stcp004_remount_store_component(dash_dcc):
 
     dash_dcc.find_element("#start").click()
     dash_dcc.wait_for_text_to_equal(
-        "#output",
-        '[{"n_clicks": null}, {"n_clicks": null}, {"n_clicks": null}]'
+        "#output", '[{"n_clicks": null}, {"n_clicks": null}, {"n_clicks": null}]'
     )
 
     dash_dcc.find_element("#btn").click()
     dash_dcc.wait_for_text_to_equal(
-        "#output",
-        '[{"n_clicks": 1}, {"n_clicks": 1}, {"n_clicks": 1}]'
+        "#output", '[{"n_clicks": 1}, {"n_clicks": 1}, {"n_clicks": 1}]'
     )
 
     dash_dcc.find_element("#clear-btn").click()
@@ -172,21 +183,18 @@ def test_stcp004_remount_store_component(dash_dcc):
 
     dash_dcc.find_element("#btn").click()
     dash_dcc.wait_for_text_to_equal(
-        "#output",
-        '[{"n_clicks": 2}, {"n_clicks": 2}, {"n_clicks": 2}]'
+        "#output", '[{"n_clicks": 2}, {"n_clicks": 2}, {"n_clicks": 2}]'
     )
 
     # now remount content components
     dash_dcc.find_element("#start").click()
     dash_dcc.wait_for_text_to_equal(
-        "#output",
-        '[{"n_clicks": null}, {"n_clicks": null}, {"n_clicks": null}]'
+        "#output", '[{"n_clicks": null}, {"n_clicks": null}, {"n_clicks": null}]'
     )
 
     dash_dcc.find_element("#btn").click()
     dash_dcc.wait_for_text_to_equal(
-        "#output",
-        '[{"n_clicks": 1}, {"n_clicks": 1}, {"n_clicks": 1}]'
+        "#output", '[{"n_clicks": 1}, {"n_clicks": 1}, {"n_clicks": 1}]'
     )
 
     assert not dash_dcc.get_logs()

--- a/tests/integration/store/test_data_lifecycle.py
+++ b/tests/integration/store/test_data_lifecycle.py
@@ -7,9 +7,7 @@ def test_stdl001_data_lifecycle_with_different_condition(store_app, dash_dcc):
     nclicks = 10
     dash_dcc.multiple_click("#btn", nclicks)
 
-    dash_dcc.wait_for_text_to_equal(
-        "#output", '{{"n_clicks": {}}}'.format(nclicks)
-    )
+    dash_dcc.wait_for_text_to_equal("#output", '{{"n_clicks": {}}}'.format(nclicks))
     assert dash_dcc.get_local_storage() == {
         "n_clicks": nclicks
     }, "local storage should contain the same click nums"

--- a/tests/integration/store/test_store_data.py
+++ b/tests/integration/store/test_store_data.py
@@ -120,8 +120,7 @@ def test_stda002_nested_data(dash_dcc):
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 6),
-    reason="tests requires depedency only available in 3.6+",
+    sys.version_info < (3, 6), reason="tests requires depedency only available in 3.6+",
 )
 @pytest.mark.parametrize("storage_type", ("memory", "local", "session"))
 def test_stda003_large_data_size(storage_type, csv_5mb, dash_dcc):

--- a/tests/integration/tab/test_tabs_with_graphs.py
+++ b/tests/integration/tab/test_tabs_with_graphs.py
@@ -17,56 +17,43 @@ def test_graph_does_not_resize_in_tabs(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
     app.layout = html.Div(
         [
-            html.H1('Dash Tabs component demo'),
+            html.H1("Dash Tabs component demo"),
             dcc.Tabs(
                 id="tabs-example",
-                value='tab-1-example',
+                value="tab-1-example",
                 children=[
-                    dcc.Tab(
-                        label='Tab One', value='tab-1-example', id='tab-1'
-                    ),
-                    dcc.Tab(
-                        label='Tab Two', value='tab-2-example', id='tab-2'
-                    ),
+                    dcc.Tab(label="Tab One", value="tab-1-example", id="tab-1"),
+                    dcc.Tab(label="Tab Two", value="tab-2-example", id="tab-2"),
                 ],
             ),
-            html.Div(id='tabs-content-example'),
+            html.Div(id="tabs-content-example"),
         ]
     )
 
     @app.callback(
-        Output('tabs-content-example', 'children'),
-        [Input('tabs-example', 'value')],
+        Output("tabs-content-example", "children"), [Input("tabs-example", "value")],
     )
     def render_content(tab):
-        if tab == 'tab-1-example':
+        if tab == "tab-1-example":
             return html.Div(
                 [
-                    html.H3('Tab content 1'),
+                    html.H3("Tab content 1"),
                     dcc.Graph(
-                        id='graph-1-tabs',
+                        id="graph-1-tabs",
                         figure={
-                            'data': [
-                                {'x': [1, 2, 3], 'y': [3, 1, 2], 'type': 'bar'}
-                            ]
+                            "data": [{"x": [1, 2, 3], "y": [3, 1, 2], "type": "bar"}]
                         },
                     ),
                 ]
             )
-        elif tab == 'tab-2-example':
+        elif tab == "tab-2-example":
             return html.Div(
                 [
-                    html.H3('Tab content 2'),
+                    html.H3("Tab content 2"),
                     dcc.Graph(
-                        id='graph-2-tabs',
+                        id="graph-2-tabs",
                         figure={
-                            'data': [
-                                {
-                                    'x': [1, 2, 3],
-                                    'y': [5, 10, 6],
-                                    'type': 'bar',
-                                }
-                            ]
+                            "data": [{"x": [1, 2, 3], "y": [5, 10, 6], "type": "bar",}]
                         },
                     ),
                 ]
@@ -74,8 +61,8 @@ def test_graph_does_not_resize_in_tabs(dash_dcc, is_eager):
 
     dash_dcc.start_server(app)
 
-    tab_one = dash_dcc.wait_for_element('#tab-1')
-    tab_two = dash_dcc.wait_for_element('#tab-2')
+    tab_one = dash_dcc.wait_for_element("#tab-1")
+    tab_two = dash_dcc.wait_for_element("#tab-2")
 
     WebDriverWait(dash_dcc.driver, 10).until(
         EC.element_to_be_clickable((By.ID, "tab-2"))
@@ -83,9 +70,7 @@ def test_graph_does_not_resize_in_tabs(dash_dcc, is_eager):
 
     # wait for Graph to be ready
     WebDriverWait(dash_dcc.driver, 10).until(
-        EC.visibility_of_element_located(
-            (By.CSS_SELECTOR, "#graph-1-tabs .main-svg")
-        )
+        EC.visibility_of_element_located((By.CSS_SELECTOR, "#graph-1-tabs .main-svg"))
     )
 
     dash_dcc.percy_snapshot(
@@ -97,9 +82,7 @@ def test_graph_does_not_resize_in_tabs(dash_dcc, is_eager):
 
     # wait for Graph to be ready
     WebDriverWait(dash_dcc.driver, 10).until(
-        EC.visibility_of_element_located(
-            (By.CSS_SELECTOR, "#graph-2-tabs .main-svg")
-        )
+        EC.visibility_of_element_located((By.CSS_SELECTOR, "#graph-2-tabs .main-svg"))
     )
 
     dash_dcc.percy_snapshot(
@@ -116,9 +99,7 @@ def test_graph_does_not_resize_in_tabs(dash_dcc, is_eager):
 
     # wait for Graph to be loaded after clicking
     WebDriverWait(dash_dcc.driver, 10).until(
-        EC.visibility_of_element_located(
-            (By.CSS_SELECTOR, "#graph-1-tabs .main-svg")
-        )
+        EC.visibility_of_element_located((By.CSS_SELECTOR, "#graph-1-tabs .main-svg"))
     )
 
     dash_dcc.percy_snapshot(
@@ -132,59 +113,53 @@ def test_graph_does_not_resize_in_tabs(dash_dcc, is_eager):
 def test_tabs_render_without_selected(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
 
-    menu = html.Div([html.Div('one', id='one'), html.Div('two', id='two')])
+    menu = html.Div([html.Div("one", id="one"), html.Div("two", id="two")])
 
     tabs_one = html.Div(
-        [dcc.Tabs([dcc.Tab(dcc.Graph(id='graph-one'), label='tab-one-one')])],
-        id='tabs-one',
-        style={'display': 'none'},
+        [dcc.Tabs([dcc.Tab(dcc.Graph(id="graph-one"), label="tab-one-one")])],
+        id="tabs-one",
+        style={"display": "none"},
     )
 
     tabs_two = html.Div(
-        [dcc.Tabs([dcc.Tab(dcc.Graph(id='graph-two'), label='tab-two-one')])],
-        id='tabs-two',
-        style={'display': 'none'},
+        [dcc.Tabs([dcc.Tab(dcc.Graph(id="graph-two"), label="tab-two-one")])],
+        id="tabs-two",
+        style={"display": "none"},
     )
 
     app.layout = html.Div([menu, tabs_one, tabs_two])
 
-    for i in ('one', 'two'):
+    for i in ("one", "two"):
 
-        @app.callback(
-            Output('tabs-{}'.format(i), 'style'), [Input(i, 'n_clicks')]
-        )
+        @app.callback(Output("tabs-{}".format(i), "style"), [Input(i, "n_clicks")])
         def on_click_update_tabs(n_clicks):
             if n_clicks is None:
                 raise PreventUpdate
 
             if n_clicks % 2 == 1:
-                return {'display': 'block'}
-            return {'display': 'none'}
+                return {"display": "block"}
+            return {"display": "none"}
 
-        @app.callback(
-            Output('graph-{}'.format(i), 'figure'), [Input(i, 'n_clicks')]
-        )
+        @app.callback(Output("graph-{}".format(i), "figure"), [Input(i, "n_clicks")])
         def on_click_update_graph(n_clicks):
             if n_clicks is None:
                 raise PreventUpdate
 
             return {
-                'data': [{'x': [1, 2, 3, 4], 'y': [4, 3, 2, 1]}],
-                'layout': {'width': 700, 'height': 450},
+                "data": [{"x": [1, 2, 3, 4], "y": [4, 3, 2, 1]}],
+                "layout": {"width": 700, "height": 450},
             }
 
     dash_dcc.start_server(app)
 
-    button_one = dash_dcc.wait_for_element('#one')
-    button_two = dash_dcc.wait_for_element('#two')
+    button_one = dash_dcc.wait_for_element("#one")
+    button_two = dash_dcc.wait_for_element("#two")
 
     button_one.click()
 
     # wait for tabs to be loaded after clicking
     WebDriverWait(dash_dcc.driver, 10).until(
-        EC.visibility_of_element_located(
-            (By.CSS_SELECTOR, "#graph-one .main-svg")
-        )
+        EC.visibility_of_element_located((By.CSS_SELECTOR, "#graph-one .main-svg"))
     )
 
     time.sleep(1)
@@ -196,9 +171,7 @@ def test_tabs_render_without_selected(dash_dcc, is_eager):
 
     # wait for tabs to be loaded after clicking
     WebDriverWait(dash_dcc.driver, 10).until(
-        EC.visibility_of_element_located(
-            (By.CSS_SELECTOR, "#graph-two .main-svg")
-        )
+        EC.visibility_of_element_located((By.CSS_SELECTOR, "#graph-two .main-svg"))
     )
 
     time.sleep(1)
@@ -213,19 +186,19 @@ def test_tabs_render_without_selected(dash_dcc, is_eager):
 
 def check_graph_config_shape(dash_dcc):
     config_schema = dash_dcc.driver.execute_script(
-        'return Plotly.PlotSchema.get().config;'
+        "return Plotly.PlotSchema.get().config;"
     )
-    with open(os.path.join(dcc.__path__[0], 'metadata.json')) as meta:
-        graph_meta = json.load(meta)['src/components/Graph.react.js']
-        config_prop_shape = graph_meta['props']['config']['type']['value']
+    with open(os.path.join(dcc.__path__[0], "metadata.json")) as meta:
+        graph_meta = json.load(meta)["src/components/Graph.react.js"]
+        config_prop_shape = graph_meta["props"]["config"]["type"]["value"]
 
     ignored_config = [
-        'setBackground',
-        'showSources',
-        'logging',
-        'globalTransforms',
-        'notifyOnLogging',
-        'role',
+        "setBackground",
+        "showSources",
+        "logging",
+        "globalTransforms",
+        "notifyOnLogging",
+        "role",
     ]
 
     def crawl(schema, props):
@@ -237,7 +210,7 @@ def check_graph_config_shape(dash_dcc):
                 continue
 
             assert item_name in props
-            if 'valType' not in item:
-                crawl(item, props[item_name]['value'])
+            if "valType" not in item:
+                crawl(item, props[item_name]["value"])
 
     crawl(config_schema, config_prop_shape)

--- a/tests/integration/tab/test_tabs_with_graphs.py
+++ b/tests/integration/tab/test_tabs_with_graphs.py
@@ -53,7 +53,7 @@ def test_graph_does_not_resize_in_tabs(dash_dcc, is_eager):
                     dcc.Graph(
                         id="graph-2-tabs",
                         figure={
-                            "data": [{"x": [1, 2, 3], "y": [5, 10, 6], "type": "bar",}]
+                            "data": [{"x": [1, 2, 3], "y": [5, 10, 6], "type": "bar"}]
                         },
                     ),
                 ]

--- a/tests/integration/upload/test_upload_different_file_types.py
+++ b/tests/integration/upload/test_upload_different_file_types.py
@@ -54,9 +54,7 @@ def load_data_by_type(filetype, contents):
 def test_upft001_test_upload_with_different_file_types(filetype, dash_dcc):
 
     filepath = os.path.join(
-        os.path.dirname(__file__),
-        "upload-assets",
-        "upft001.{}".format(filetype),
+        os.path.dirname(__file__), "upload-assets", "upft001.{}".format(filetype),
     )
 
     app = dash.Dash(__name__)
@@ -68,9 +66,7 @@ def test_upft001_test_upload_with_different_file_types(filetype, dash_dcc):
                 id="upload-div",
                 children=dcc.Upload(
                     id="upload",
-                    children=html.Div(
-                        ["Drag and Drop or ", html.A("Select a File")]
-                    ),
+                    children=html.Div(["Drag and Drop or ", html.A("Select a File")]),
                     style={
                         "width": "100%",
                         "height": "60px",

--- a/tests/test_integration_2.py
+++ b/tests/test_integration_2.py
@@ -82,9 +82,7 @@ class Test2(IntegrationTests):
         page_content = self.wait_for_element_by_css_selector("#page-content")
         self.assertNotEqual(page_content.text, "You are on page /")
 
-        self.wait_for_text_to_equal(
-            "#page-content", "You are on page /test-link"
-        )
+        self.wait_for_text_to_equal("#page-content", "You are on page /test-link")
 
         # test if rendered Link's <a> tag has a href attribute
         link_href = test_link.get_attribute("href")
@@ -102,9 +100,7 @@ class Test2(IntegrationTests):
             ]
         )
 
-        @app.callback(
-            Output("output", "children"), [Input("interval", "n_intervals")]
-        )
+        @app.callback(Output("output", "children"), [Input("interval", "n_intervals")])
         def update_text(n):
             return "{}".format(n)
 
@@ -120,10 +116,7 @@ class Test2(IntegrationTests):
         app.layout = html.Div(
             [
                 dcc.Interval(
-                    id="interval",
-                    interval=100,
-                    n_intervals=0,
-                    max_intervals=-1,
+                    id="interval", interval=100, n_intervals=0, max_intervals=-1,
                 ),
                 html.Button("Start", id="start", n_clicks_timestamp=-1),
                 html.Button("Stop", id="stop", n_clicks_timestamp=-1),
@@ -144,9 +137,7 @@ class Test2(IntegrationTests):
             else:
                 return -1
 
-        @app.callback(
-            Output("output", "children"), [Input("interval", "n_intervals")]
-        )
+        @app.callback(Output("output", "children"), [Input("interval", "n_intervals")])
         def display_data(n_intervals):
             return "Updated {}".format(n_intervals)
 
@@ -189,10 +180,7 @@ class Test2(IntegrationTests):
                 ],
             )
             def _on_confirmed(
-                submit_n_clicks,
-                cancel_n_clicks,
-                submit_timestamp,
-                cancel_timestamp,
+                submit_n_clicks, cancel_n_clicks, submit_timestamp, cancel_timestamp,
             ):
                 if not submit_n_clicks and not cancel_n_clicks:
                     return ""
@@ -227,9 +215,7 @@ class Test2(IntegrationTests):
 
         if add_callback:
             self.assertEqual(
-                2,
-                count.value,
-                "Expected 2 callback but got " + str(count.value),
+                2, count.value, "Expected 2 callback but got " + str(count.value),
             )
 
     def test_confirm(self):
@@ -243,9 +229,7 @@ class Test2(IntegrationTests):
             ]
         )
 
-        @app.callback(
-            Output("confirm", "displayed"), [Input("button", "n_clicks")]
-        )
+        @app.callback(Output("confirm", "displayed"), [Input("button", "n_clicks")])
         def on_click_confirm(n_clicks):
             if n_clicks:
                 return True
@@ -296,8 +280,7 @@ class Test2(IntegrationTests):
         )
 
         @app.callback(
-            Output("confirm-container", "children"),
-            [Input("button", "n_clicks")],
+            Output("confirm-container", "children"), [Input("button", "n_clicks")],
         )
         def on_click(n_clicks):
             if n_clicks:
@@ -317,9 +300,7 @@ class Test2(IntegrationTests):
     def test_user_supplied_css(self):
         app = dash.Dash(__name__)
 
-        app.layout = html.Div(
-            className="test-input-css", children=[dcc.Input()]
-        )
+        app.layout = html.Div(className="test-input-css", children=[dcc.Input()])
 
         self.startServer(app)
 
@@ -343,9 +324,7 @@ class Test2(IntegrationTests):
             ]
         )
 
-        @app.callback(
-            Output("content", "children"), [Input("location", "pathname")]
-        )
+        @app.callback(Output("content", "children"), [Input("location", "pathname")])
         def on_location(location_path):
             if location_path is None:
                 raise PreventUpdate
@@ -365,9 +344,7 @@ class Test2(IntegrationTests):
         time.sleep(1)
         self.snapshot("Logout button")
 
-        self.assertEqual(
-            "logged-in", self.driver.get_cookie("logout-cookie")["value"]
-        )
+        self.assertEqual("logged-in", self.driver.get_cookie("logout-cookie")["value"])
         logout_button = self.wait_for_element_by_css_selector("#logout-btn")
         logout_button.click()
         self.wait_for_text_to_equal("#content", "Logged out")
@@ -379,17 +356,13 @@ class Test2(IntegrationTests):
         app.layout = html.Div(
             [
                 dcc.Input(id="input"),
-                html.Div(
-                    html.Div([1.5, None, "string", html.Div(id="output-1")])
-                ),
+                html.Div(html.Div([1.5, None, "string", html.Div(id="output-1")])),
             ]
         )
 
         call_count = Value("i", 0)
 
-        @app.callback(
-            Output("output-1", "children"), [Input("input", "value")]
-        )
+        @app.callback(Output("output-1", "children"), [Input("input", "value")])
         def update_output(value):
             call_count.value = call_count.value + 1
             return value
@@ -443,7 +416,5 @@ class Test2(IntegrationTests):
         )
 
         WebDriverWait(self.driver, TIMEOUT).until(
-            EC.visibility_of_element_located(
-                (By.CSS_SELECTOR, ".tab--disabled")
-            )
+            EC.visibility_of_element_located((By.CSS_SELECTOR, ".tab--disabled"))
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,31 +5,28 @@ TIMEOUT = 20
 
 class WaitForTimeout(Exception):
     """This should only be raised inside the `wait_for` function."""
+
     pass
 
 
 def assert_clean_console(TestClass):
     def assert_no_console_errors(TestClass):
         TestClass.assertEqual(
-            TestClass.driver.execute_script(
-                'return window.tests.console.error.length'
-            ),
-            0
+            TestClass.driver.execute_script("return window.tests.console.error.length"),
+            0,
         )
 
     def assert_no_console_warnings(TestClass):
         TestClass.assertEqual(
-            TestClass.driver.execute_script(
-                'return window.tests.console.warn.length'
-            ),
-            0
+            TestClass.driver.execute_script("return window.tests.console.warn.length"),
+            0,
         )
 
     assert_no_console_warnings(TestClass)
     assert_no_console_errors(TestClass)
 
 
-def wait_for(condition_function, get_message=lambda: '', *args, **kwargs):
+def wait_for(condition_function, get_message=lambda: "", *args, **kwargs):
     """
     Waits for condition_function to return True or raises WaitForTimeout.
     :param (function) condition_function: Should return True on success.
@@ -47,6 +44,7 @@ def wait_for(condition_function, get_message=lambda: '', *args, **kwargs):
             self.fail('element never appeared...')
         plot = get_element(selector)  # we know it exists.
     """
+
     def wrapped_condition_function():
         """We wrap this to alter the call base on the closure."""
         if args and kwargs:
@@ -57,9 +55,9 @@ def wait_for(condition_function, get_message=lambda: '', *args, **kwargs):
             return condition_function(**kwargs)
         return condition_function()
 
-    if 'timeout' in kwargs:
-        timeout = kwargs['timeout']
-        del kwargs['timeout']
+    if "timeout" in kwargs:
+        timeout = kwargs["timeout"]
+        del kwargs["timeout"]
     else:
         timeout = TIMEOUT
 


### PR DESCRIPTION
Fixed non-functional string comparison in `private::lint:black`
by adding `$` prefix to `PYTHON_VERSION`.

Made the conditional POSIX compliant by removing the double
bracket bashism and using escaped double quotes. This is
**not** academic -- the CircleCI image used to build this
package uses `dash` as its default shell, and `[[` doesn't work
in `dash`.