### PR TITLE
Remove outdated lint commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "private::lint.prettier": "prettier --config .prettierrc src/**/*.js tests/unit/*.js --list-different",
     "prepublishOnly": "rm -rf lib && babel src --out-dir lib --copy-files",
     "start": "webpack-serve ./webpack.serve.config.js --open",
-    "test": "run-s -c lint lint:py format:test test-unit test:legacy test:intg test:pyimport",
+    "test": "run-s -c lint test-unit test:legacy test:intg test:pyimport",
     "test:legacy": "pytest tests/test_integration*.py",
     "test:intg": "pytest --nopercyfinalize --headless tests/integration",
     "test:pyimport": "python -m unittest tests/test_dash_import.py",


### PR DESCRIPTION
As discovered here https://github.com/plotly/dash-core-components/issues/849