### PR TITLE
Upload timestamp

### DIFF
--- a/src/components/Upload.react.js
+++ b/src/components/Upload.react.js
@@ -74,6 +74,11 @@ Upload.propTypes = {
     ]),
 
     /**
+     * Timestamp of last completed upload in unix time (seconds since 1970)
+     */
+    upload_timestamp: PropTypes.oneOfType([PropTypes.number]),
+
+    /**
      * Contents of the upload component
      */
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),

--- a/src/fragments/Upload.react.js
+++ b/src/fragments/Upload.react.js
@@ -15,6 +15,7 @@ export default class Upload extends Component {
             contents: [],
             filename: [],
             last_modified: [],
+            upload_timestamp: -1,
         };
         files.forEach(file => {
             const reader = new FileReader();
@@ -28,6 +29,7 @@ export default class Upload extends Component {
                 newProps.filename.push(file.name);
                 // eslint-disable-next-line no-magic-numbers
                 newProps.last_modified.push(file.lastModified / 1000);
+                newProps.upload_timestamp = Date.now();
                 if (newProps.contents.length === files.length) {
                     if (multiple) {
                         setProps(newProps);
@@ -36,6 +38,7 @@ export default class Upload extends Component {
                             contents: newProps.contents[0],
                             filename: newProps.filename[0],
                             last_modified: newProps.last_modified[0],
+                            upload_timestamp: newProps.upload_timestamp,
                         });
                     }
                 }


### PR DESCRIPTION
Resolves #816 by allowing users to trigger callback off Input "upload_timestamp" property which is guaranteed to update every time a file is uploaded, even if the same file is uploaded repeatedly. Uploaded file contents, filename, and last_modified properties can be accessed through States.