### PR TITLE
Robustify test `stdl001`

### DIFF
--- a/tests/integration/store/test_data_lifecycle.py
+++ b/tests/integration/store/test_data_lifecycle.py
@@ -16,9 +16,7 @@ def test_stdl001_data_lifecycle_with_different_condition(store_app, dash_dcc):
     }, "session storage should contain the same click nums"
 
     dash_dcc.driver.refresh()
-    assert dash_dcc.find_element("#output").text == '"{}"'.format(
-        store_app.uuid
-    ), "a browser refresh will clear the memory type data to initial data"
+    dash_dcc.wait_for_text_to_equal("#output", '"{}"'.format(store_app.uuid))
     assert dash_dcc.get_local_storage() == {"n_clicks": nclicks}
     assert dash_dcc.get_session_storage() == {"n_clicks": nclicks}
 
@@ -27,9 +25,7 @@ def test_stdl001_data_lifecycle_with_different_condition(store_app, dash_dcc):
     assert dash_dcc.get_local_storage() == {
         "n_clicks": nclicks
     }, "local storage should be persistent"
-    assert dash_dcc.find_element("#output").text == '"{}"'.format(
-        store_app.uuid
-    ), "memory storage should contain the initial data in new tab"
+    dash_dcc.wait_for_text_to_equal("#output", '"{}"'.format(store_app.uuid))
 
     dash_dcc.multiple_click("#btn", 2)
     wait.until(lambda: dash_dcc.get_session_storage() == {"n_clicks": 2}, timeout=1)
@@ -40,9 +36,7 @@ def test_stdl001_data_lifecycle_with_different_condition(store_app, dash_dcc):
     dash_dcc.driver.close()
     dash_dcc.switch_window()
     assert dash_dcc.get_local_storage() == {"n_clicks": 2}
-    assert dash_dcc.find_element("#output").text == '"{}"'.format(
-        store_app.uuid
-    ), "memory output should be the same as after previous refresh"
+    dash_dcc.wait_for_text_to_equal("#output", '"{}"'.format(store_app.uuid))
     assert dash_dcc.get_session_storage() == {
         "n_clicks": nclicks
     }, "session storage should be specific per browser tab window"


### PR DESCRIPTION
Issue encountered as part of reviewing #889

stdl001 fails from time to time because the field's text hasn't had time to update itself.

Update to use wait_for_text_to_equal instead of an assertion.