### PR TITLE
Bump plotly.js v1.58.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Updated
-- [#889](https://github.com/plotly/dash-core-components/pull/889)
-  - Upgraded Plotly.js to [1.58.0](https://github.com/plotly/plotly.js/releases/tag/v1.58.0)
+- [#889](https://github.com/plotly/dash-core-components/pull/889) & [#893](https://github.com/plotly/dash-core-components/pull/893)
+  - Upgraded Plotly.js to [1.58.1](https://github.com/plotly/plotly.js/releases/tag/v1.58.1)
+    - Patch Release [1.58.1](https://github.com/plotly/plotly.js/releases/tag/v1.58.1)
     - [Feature release of Plotly.js 1.58.0](https://github.com/plotly/plotly.js/releases/tag/v1.58.0) which:
       - Add `ticklabelposition` attribute to cartesian axes and colorbars [#5275](https://github.com/plotly/plotly.js/pull/5275)
       - Add "strict" `autotypenumbers` to axes and `layout` [#5240](https://github.com/plotly/plotly.js/pull/5240)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13023,9 +13023,9 @@
       }
     },
     "plotly.js": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.58.0.tgz",
-      "integrity": "sha512-w1Z/eaAUZolh2aZZud/6Gb0SLHRVtGOAzCZIrzMGjKJ9eq7dfpYUdfSWj2W7+AQieU+Lc8OpgxknhCYwbT216A==",
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.58.1.tgz",
+      "integrity": "sha512-EzVx3Aipr7WyefMDHJFRtIkJKSI9fTTipGu5fQ17l5M5FzsDq+bdywhJ3Gy645el5QBPx5uzrY80JJbZTjYSQQ==",
       "requires": {
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fast-isnumeric": "^1.1.3",
     "highlight.js": "^10.3.1",
     "moment": "^2.20.1",
-    "plotly.js": "1.58.0",
+    "plotly.js": "1.58.1",
     "prop-types": "^15.6.0",
     "ramda": "^0.26.1",
     "rc-slider": "^9.1.0",


### PR DESCRIPTION
I run `npm ci` followed by `npm install --save-exact plotly.js@1.58.1`.

@Marc-Andre-Rivet 
Please see https://github.com/plotly/plotly.js/releases/tag/v1.58.1
and update the CHANGELOG.
Thank you!

cc: @nicolaskruchten 

