### PR TITLE
Dont clone figure.layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 ### Fixed
-- [#903](https://github.com/plotly/dash-core-components/pull/903) - part of fixing dash import bug https://github.com/plotly/dash/issues/1143
+- [#905](https://github.com/plotly/dash-core-components/pull/905) Make sure the `figure` prop of `dcc.Graph` receives updates from user interactions in the graph, by using the same `layout` object as provided in the prop rather than cloning it. Fixes [#879](https://github.com/plotly/dash-core-components/issues/879).
+- [#903](https://github.com/plotly/dash-core-components/pull/903) Part of fixing dash import bug https://github.com/plotly/dash/issues/1143
 
 ### Updated
-- [#911](https://github.com/plotly/dash-core-components/pull/911)
+- [#911](https://github.com/plotly/dash-core-components/pull/911), [#906](https://github.com/plotly/dash-core-components/pull/906)
+  - Upgraded Plotly.js to [1.58.4](https://github.com/plotly/plotly.js/releases/tag/v1.58.4)
     - Patch Release [1.58.4](https://github.com/plotly/plotly.js/releases/tag/v1.58.4)
-- [#906](https://github.com/plotly/dash-core-components/pull/906)
     - Patch Release [1.58.3](https://github.com/plotly/plotly.js/releases/tag/v1.58.3)
 
 ## [1.14.1] - 2020-12-09

--- a/dash_core_components_base/__init__.py
+++ b/dash_core_components_base/__init__.py
@@ -19,7 +19,7 @@ if not hasattr(_dash, '__plotly_dash') and not hasattr(_dash, 'development'):
           "named \n'dash.py' in your current directory.", file=_sys.stderr)
     _sys.exit(1)
 
-from ._imports_ import *  # noqa: F401, F403
+from ._imports_ import *  # noqa: F401, F403, E402
 from ._imports_ import __all__  # noqa: E402
 
 _current_path = _os.path.dirname(_os.path.abspath(__file__))

--- a/src/fragments/Graph.react.js
+++ b/src/fragments/Graph.react.js
@@ -131,6 +131,8 @@ class PlotlyGraph extends Component {
         this.getLayoutOverride = this.getLayoutOverride.bind(this);
         this.graphResize = this.graphResize.bind(this);
         this.isResponsive = this.isResponsive.bind(this);
+
+        this.state = {override: {}, originals: {}};
     }
 
     plot(props) {
@@ -227,8 +229,7 @@ class PlotlyGraph extends Component {
             return layout;
         }
         const override = this.getLayoutOverride(responsive);
-        const prev_override = (this.state && this.state.override) || {};
-        const prev_originals = (this.state && this.state.originals) || {};
+        const {override: prev_override, originals: prev_originals} = this.state;
         // Store the original data that we're about to override
         const originals = {};
         for (const key in override) {
@@ -238,7 +239,7 @@ class PlotlyGraph extends Component {
                 originals[key] = prev_originals[key];
             }
         }
-        this.setState({override: override, originals: originals});
+        this.setState({override, originals});
         // Undo the previous override, but only for keys that the user did not change
         for (const key in prev_originals) {
             if (layout[key] === prev_override[key]) {

--- a/src/fragments/Graph.react.js
+++ b/src/fragments/Graph.react.js
@@ -226,8 +226,23 @@ class PlotlyGraph extends Component {
         if (!layout) {
             return layout;
         }
-        let override = this.getLayoutOverride(responsive);
-        for (let key in override) {
+        const override = this.getLayoutOverride(responsive);
+        const prev_layout = this.gd.current.layout;  // === this.props.figure.layout
+        const prev_override_originals = (this.state && this.state.override_originals) || {};
+        // Store the original data that we're about to override
+        const override_originals = {};
+        for (const key in override) {
+            override_originals[key] = layout[key];
+        }
+        this.setState({override_originals: override_originals});
+        // Undo the previous override, but only for keys that the user did not change
+        for (const key in prev_override_originals) {
+            if (layout[key] === prev_layout[key]) {
+                layout[key] = prev_override_originals[key];
+            }
+        }
+        // Apply the current override
+        for (const key in override) {
             layout[key] = override[key];
         }
         return layout;  // not really a clone

--- a/src/fragments/Graph.react.js
+++ b/src/fragments/Graph.react.js
@@ -151,13 +151,12 @@ class PlotlyGraph extends Component {
         }
 
         const configClone = this.getConfig(config, responsive);
-        const layoutClone = this.getLayout(figure.layout, responsive);
 
         gd.classList.add('dash-graph--pending');
 
         return Plotly.react(gd, {
             data: figure.data,
-            layout: layoutClone,
+            layout: figure.layout,
             frames: figure.frames,
             config: configClone,
         }).then(() => {

--- a/src/fragments/Graph.react.js
+++ b/src/fragments/Graph.react.js
@@ -227,19 +227,22 @@ class PlotlyGraph extends Component {
             return layout;
         }
         const override = this.getLayoutOverride(responsive);
-        const prev_layout = this.gd.current.layout; // === this.props.figure.layout
-        const prev_override_originals =
-            (this.state && this.state.override_originals) || {};
+        const prev_override = (this.state && this.state.override) || {};
+        const prev_originals = (this.state && this.state.originals) || {};
         // Store the original data that we're about to override
-        const override_originals = {};
+        const originals = {};
         for (const key in override) {
-            override_originals[key] = layout[key];
+            if (layout[key] !== prev_override[key]) {
+                originals[key] = layout[key];
+            } else if (prev_originals.hasOwnProperty(key)) {
+                originals[key] = prev_originals[key];
+            }
         }
-        this.setState({override_originals: override_originals});
+        this.setState({override: override, originals: originals});
         // Undo the previous override, but only for keys that the user did not change
-        for (const key in prev_override_originals) {
-            if (layout[key] === prev_layout[key]) {
-                layout[key] = prev_override_originals[key];
+        for (const key in prev_originals) {
+            if (layout[key] === prev_override[key]) {
+                layout[key] = prev_originals[key];
             }
         }
         // Apply the current override

--- a/src/fragments/Graph.react.js
+++ b/src/fragments/Graph.react.js
@@ -151,12 +151,13 @@ class PlotlyGraph extends Component {
         }
 
         const configClone = this.getConfig(config, responsive);
+        const layoutClone = this.getLayout(figure.layout, responsive);
 
         gd.classList.add('dash-graph--pending');
 
         return Plotly.react(gd, {
             data: figure.data,
-            layout: figure.layout,
+            layout: layoutClone,
             frames: figure.frames,
             config: configClone,
         }).then(() => {
@@ -225,8 +226,11 @@ class PlotlyGraph extends Component {
         if (!layout) {
             return layout;
         }
-
-        return mergeDeepRight(layout, this.getLayoutOverride(responsive));
+        let override = this.getLayoutOverride(responsive);
+        for (let key in override) {
+            layout[key] = override[key];
+        }
+        return layout;  // not really a clone
     }
 
     getConfigOverride(responsive) {

--- a/src/fragments/Graph.react.js
+++ b/src/fragments/Graph.react.js
@@ -227,8 +227,9 @@ class PlotlyGraph extends Component {
             return layout;
         }
         const override = this.getLayoutOverride(responsive);
-        const prev_layout = this.gd.current.layout;  // === this.props.figure.layout
-        const prev_override_originals = (this.state && this.state.override_originals) || {};
+        const prev_layout = this.gd.current.layout; // === this.props.figure.layout
+        const prev_override_originals =
+            (this.state && this.state.override_originals) || {};
         // Store the original data that we're about to override
         const override_originals = {};
         for (const key in override) {
@@ -245,7 +246,7 @@ class PlotlyGraph extends Component {
         for (const key in override) {
             layout[key] = override[key];
         }
-        return layout;  // not really a clone
+        return layout; // not really a clone
     }
 
     getConfigOverride(responsive) {

--- a/tests/dash_core_components_page.py
+++ b/tests/dash_core_components_page.py
@@ -118,3 +118,12 @@ class DashCoreComponentsMixin(object):
 
     def release(self):
         ActionChains(self.driver).release().perform()
+
+    def click_and_drag_at_coord_fractions(self, elem_or_selector, fx1, fy1, fx2, fy2):
+        elem = self._get_element(elem_or_selector)
+
+        ActionChains(self.driver).move_to_element_with_offset(
+            elem, elem.size["width"] * fx1, elem.size["height"] * fy1
+        ).click_and_hold().move_to_element_with_offset(
+            elem, elem.size["width"] * fx2, elem.size["height"] * fy2
+        ).release().perform()

--- a/tests/integration/graph/test_graph_varia.py
+++ b/tests/integration/graph/test_graph_varia.py
@@ -690,7 +690,7 @@ def test_shapes_not_lost(dash_dcc):
 
     dash_dcc.start_server(app)
     button = dash_dcc.wait_for_element("#button")
-    time.sleep(1)
+    dash_dcc.wait_for_text_to_equal("#output", "0")
 
     # Draw a shape
     dash_dcc.click_and_hold_at_coord_fractions("#graph", 0.25, 0.25)
@@ -754,19 +754,15 @@ def test_originals_maintained_for_responsive_override(dash_dcc):
 
     dash_dcc.start_server(app)
     button = dash_dcc.wait_for_element("#button")
-    time.sleep(1)
-
-    # Draw a shape
-    dash_dcc.release()
 
     # Initial values of autosize and width
     dash_dcc.wait_for_text_to_equal("#output", "null 300")
-    button.click()
     # Values for responsive is true
+    button.click()
     dash_dcc.wait_for_text_to_equal("#output", "true undefined")
-    button.click()
     # Values for responsive is false
-    dash_dcc.wait_for_text_to_equal("#output", "false 300")
     button.click()
+    dash_dcc.wait_for_text_to_equal("#output", "false 300")
     # Values for responsive is null
+    button.click()
     dash_dcc.wait_for_text_to_equal("#output", "null 300")

--- a/tests/integration/graph/test_graph_varia.py
+++ b/tests/integration/graph/test_graph_varia.py
@@ -690,7 +690,6 @@ def test_shapes_not_lost(dash_dcc):
 
     dash_dcc.start_server(app)
     button = dash_dcc.wait_for_element("#button")
-    output = dash_dcc.wait_for_element("#output")
     time.sleep(1)
 
     # Draw a shape

--- a/tests/integration/graph/test_graph_varia.py
+++ b/tests/integration/graph/test_graph_varia.py
@@ -2,7 +2,6 @@
 import pytest
 import time
 import json
-import plotly
 import dash
 from dash.dependencies import Input, Output, State
 import dash_html_components as html
@@ -665,17 +664,15 @@ def test_shapes_not_lost(dash_dcc):
     # See issue #879
     app = dash.Dash(__name__)
 
-    fig = plotly.graph_objects.Figure(data=[])
-    fig.update_layout(dragmode="drawrect")
+    fig = {"data": [], "layout": {"dragmode": "drawrect"}}
     graph = dcc.Graph(id="graph", figure=fig)
-    graph.config = {"modeBarButtonsToAdd": ["drawrect"]}
 
     app.layout = html.Div(
         [
             graph,
             html.Br(),
-            html.Button(id='button', children="Clone figure"),
-            html.Div(id='output', children=""),
+            html.Button(id="button", children="Clone figure"),
+            html.Div(id="output", children=""),
         ]
     )
 

--- a/tests/integration/graph/test_graph_varia.py
+++ b/tests/integration/graph/test_graph_varia.py
@@ -665,7 +665,7 @@ def test_grva008_shapes_not_lost(dash_dcc):
     app = dash.Dash(__name__)
 
     fig = {"data": [], "layout": {"dragmode": "drawrect"}}
-    graph = dcc.Graph(id="graph", figure=fig)
+    graph = dcc.Graph(id="graph", figure=fig, style={"height": "400px"})
 
     app.layout = html.Div(
         [
@@ -677,15 +677,17 @@ def test_grva008_shapes_not_lost(dash_dcc):
     )
 
     app.clientside_callback(
-        """function clone_figure(_, figure) {
+        """
+        function clone_figure(_, figure) {
             let new_figure = {...figure};
             let shapes = new_figure.layout.shapes || [];
             return [new_figure, shapes.length];
         }
         """,
-        [Output("graph", "figure"), Output("output", "children")],
-        [Input("button", "n_clicks")],
-        [State("graph", "figure")],
+        Output("graph", "figure"),
+        Output("output", "children"),
+        Input("button", "n_clicks"),
+        State("graph", "figure"),
     )
 
     dash_dcc.start_server(app)
@@ -721,7 +723,7 @@ def test_grva009_originals_maintained_for_responsive_override(dash_dcc):
     app = dash.Dash(__name__)
 
     fig = {"data": [], "layout": {"autosize": None, "width": 300, "height": 300}}
-    graph = dcc.Graph(id="graph", figure=fig)
+    graph = dcc.Graph(id="graph", figure=fig, style={"height": "400px"})
 
     app.layout = html.Div(
         [
@@ -735,21 +737,24 @@ def test_grva009_originals_maintained_for_responsive_override(dash_dcc):
     # Each time that the button is pressed we change responsive mode.
     # It goes from null (default), to true, false, and back to null.
     app.clientside_callback(
-        """function clone_figure(_, figure) {
+        """
+        function clone_figure(_, figure) {
             let new_figure = {...figure};
             let index = window.internal_state_905 || 0;
             window.internal_state_905 = index + 1;
-        let responsive = [true, false, null, null][index];
-        return [new_figure, responsive, figure.layout.autosize + ' ' + figure.layout.width];
+            let responsive = [true, false, null, null][index];
+            return [
+                new_figure,
+                responsive,
+                figure.layout.autosize + ' ' + figure.layout.width
+            ];
         }
         """,
-        [
-            Output("graph", "figure"),
-            Output("graph", "responsive"),
-            Output("output", "children"),
-        ],
-        [Input("button", "n_clicks")],
-        [State("graph", "figure")],
+        Output("graph", "figure"),
+        Output("graph", "responsive"),
+        Output("output", "children"),
+        Input("button", "n_clicks"),
+        State("graph", "figure"),
     )
 
     dash_dcc.start_server(app)

--- a/tests/integration/graph/test_graph_varia.py
+++ b/tests/integration/graph/test_graph_varia.py
@@ -25,7 +25,7 @@ def findAsyncPlotlyJs(scripts):
 
 
 @pytest.mark.parametrize("is_eager", [True, False])
-def test_candlestick(dash_dcc, is_eager):
+def test_grva001_candlestick(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
     app.layout = html.Div(
         [
@@ -75,7 +75,7 @@ def test_candlestick(dash_dcc, is_eager):
 
 
 @pytest.mark.parametrize("is_eager", [True, False])
-def test_graphs_with_different_figures(dash_dcc, is_eager):
+def test_grva002_graphs_with_different_figures(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
     app.layout = html.Div(
         [
@@ -160,7 +160,7 @@ def test_graphs_with_different_figures(dash_dcc, is_eager):
 
 
 @pytest.mark.parametrize("is_eager", [True, False])
-def test_empty_graph(dash_dcc, is_eager):
+def test_grva003_empty_graph(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
 
     app.layout = html.Div(
@@ -193,7 +193,7 @@ def test_empty_graph(dash_dcc, is_eager):
 
 
 @pytest.mark.parametrize("is_eager", [True, False])
-def test_graph_prepend_trace(dash_dcc, is_eager):
+def test_grva004_graph_prepend_trace(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
 
     def generate_with_id(id, data=None):
@@ -358,7 +358,7 @@ def test_graph_prepend_trace(dash_dcc, is_eager):
 
 
 @pytest.mark.parametrize("is_eager", [True, False])
-def test_graph_extend_trace(dash_dcc, is_eager):
+def test_grva005_graph_extend_trace(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
 
     def generate_with_id(id, data=None):
@@ -521,7 +521,7 @@ def test_graph_extend_trace(dash_dcc, is_eager):
 
 
 @pytest.mark.parametrize("is_eager", [True, False])
-def test_unmounted_graph_resize(dash_dcc, is_eager):
+def test_grva006_unmounted_graph_resize(dash_dcc, is_eager):
     app = dash.Dash(__name__, eager_loading=is_eager)
 
     app.layout = html.Div(
@@ -619,7 +619,7 @@ def test_unmounted_graph_resize(dash_dcc, is_eager):
     dash_dcc.driver.set_window_size(window_size["width"], window_size["height"])
 
 
-def test_external_plotlyjs_prevents_lazy(dash_dcc):
+def test_grva007_external_plotlyjs_prevents_lazy(dash_dcc):
     app = dash.Dash(
         __name__,
         eager_loading=False,
@@ -660,7 +660,7 @@ def test_external_plotlyjs_prevents_lazy(dash_dcc):
     assert findAsyncPlotlyJs(scripts) is None
 
 
-def test_shapes_not_lost(dash_dcc):
+def test_grva008_shapes_not_lost(dash_dcc):
     # See issue #879 and pr #905
     app = dash.Dash(__name__)
 
@@ -713,7 +713,7 @@ def test_shapes_not_lost(dash_dcc):
     dash_dcc.wait_for_text_to_equal("#output", "2")
 
 
-def test_originals_maintained_for_responsive_override(dash_dcc):
+def test_grva009_originals_maintained_for_responsive_override(dash_dcc):
     # In #905 we made changes to prevent shapes from being lost.
     # This test makes sure that the overrides applied by the `responsive`
     # prop are "undone" when the `responsive` prop changes.


### PR DESCRIPTION
Fixes #879 (hopefully)

This small changes fixes the issue (for e.g. the example below). That said, I cannot oversee whether this potentially breaks other code. In theory, the tests will tell ;)

Example to test this:
```py
import dash
import dash_html_components as html
import dash_core_components as dcc
from dash.dependencies import Input, Output, State


app = dash.Dash(__name__, update_title=None)

fig = {"data": [], "layout": {"dragmode": "drawrect"}}
graph = dcc.Graph(id="graph", figure=fig)

app.layout = html.Div(
    [
        graph,
        html.Br(),
        html.Button(id='button', children="Clone figure"),
        html.Div(id='output', children=""),
    ]
)

app.clientside_callback(
    """function clone_figure(_, figure) {
        let new_figure = {...figure};
        let shapes = new_figure.layout.shapes || [];
        return [new_figure, shapes.length];
    }
    """,
    [Output("graph", "figure"), Output("output", "children")],
    [Input("button", "n_clicks")],
    [State("graph", "figure")],
)



if __name__ == "__main__":
    app.run_server(debug=True)
```