### PR TITLE
Bump plotly.js v1.58.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [#903](https://github.com/plotly/dash-core-components/pull/903) - part of fixing dash import bug https://github.com/plotly/dash/issues/1143
 
+### Updated
+- [#906](https://github.com/plotly/dash-core-components/pull/906)
+    - Patch Release [1.58.3](https://github.com/plotly/plotly.js/releases/tag/v1.58.3)
+
 ## [1.14.1] - 2020-12-09
 ### Updated
 - [#898](https://github.com/plotly/dash-core-components/pull/898)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12963,9 +12963,9 @@
       }
     },
     "plotly.js": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.58.2.tgz",
-      "integrity": "sha512-CQ1Fg50BafIeFs3PQ8D2byigrmn5UoOMJHgyLBcYoHxxQTI9L85xKl02EkiJxg7KJUgNr//Bt/yu8heAIy10XQ==",
+      "version": "1.58.3",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.58.3.tgz",
+      "integrity": "sha512-gq/bm+bpYn+NIDDfRDgLtUpFJlwCu5/H0k++M/92g+gKmTkMMn/ADqVL8mHmGtD2KY5DeOkMthw6DwG+ZCEBrQ==",
       "requires": {
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fast-isnumeric": "^1.1.3",
     "highlight.js": "^10.3.1",
     "moment": "^2.20.1",
-    "plotly.js": "1.58.2",
+    "plotly.js": "1.58.3",
     "prop-types": "^15.6.0",
     "ramda": "^0.26.1",
     "rc-slider": "^9.1.0",


### PR DESCRIPTION
I run `npm ci` followed by `npm install --save-exact plotly.js@1.58.3`.

@Marc-Andre-Rivet 
Please see https://github.com/plotly/plotly.js/releases/tag/v1.58.3
and update the CHANGELOG.
Thank you!

cc: @nicolaskruchten @alexcjohnson 

