### PR TITLE
Bump plotly.js v1.58.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#903](https://github.com/plotly/dash-core-components/pull/903) - part of fixing dash import bug https://github.com/plotly/dash/issues/1143
 
 ### Updated
+- [#911](https://github.com/plotly/dash-core-components/pull/911)
+    - Patch Release [1.58.4](https://github.com/plotly/plotly.js/releases/tag/v1.58.4)
 - [#906](https://github.com/plotly/dash-core-components/pull/906)
     - Patch Release [1.58.3](https://github.com/plotly/plotly.js/releases/tag/v1.58.3)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12963,9 +12963,9 @@
       }
     },
     "plotly.js": {
-      "version": "1.58.3",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.58.3.tgz",
-      "integrity": "sha512-gq/bm+bpYn+NIDDfRDgLtUpFJlwCu5/H0k++M/92g+gKmTkMMn/ADqVL8mHmGtD2KY5DeOkMthw6DwG+ZCEBrQ==",
+      "version": "1.58.4",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.58.4.tgz",
+      "integrity": "sha512-hdt/aEvkPjS1HJ7tJKcPqsqi9ErEZPhUFs4d2ANTLeBim+AmVcHzS1rtwr7ZrVCINgliW/+92u81omJoy+lbUw==",
       "requires": {
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fast-isnumeric": "^1.1.3",
     "highlight.js": "^10.3.1",
     "moment": "^2.20.1",
-    "plotly.js": "1.58.3",
+    "plotly.js": "1.58.4",
     "prop-types": "^15.6.0",
     "ramda": "^0.26.1",
     "rc-slider": "^9.1.0",


### PR DESCRIPTION
I run `npm ci` followed by `npm install --save-exact plotly.js@1.58.4`.

@Marc-Andre-Rivet
Please update the CHANGELOG according to https://github.com/plotly/plotly.js/releases/tag/v1.58.4
Thank you!

cc: @nicolaskruchten @alexcjohnson 