### PR TITLE
update docstring to work with dash #1531

### DIFF
--- a/src/components/Location.react.js
+++ b/src/components/Location.react.js
@@ -133,13 +133,13 @@ Location.propTypes = {
      */
     id: PropTypes.string.isRequired,
 
-    /** pathname in window.location - e.g., "/my/full/pathname" */
+    /** pathname in window.location - e.g., '/my/full/pathname' */
     pathname: PropTypes.string,
-    /** search in window.location - e.g., "?myargument=1" */
+    /** search in window.location - e.g., '?myargument=1' */
     search: PropTypes.string,
-    /** hash in window.location - e.g., "#myhash" */
+    /** hash in window.location - e.g., '#myhash' */
     hash: PropTypes.string,
-    /** href in window.location - e.g., "/my/full/pathname?myargument=1#myhash" */
+    /** href in window.location - e.g., '/my/full/pathname?myargument=1#myhash' */
     href: PropTypes.string,
 
     /** Refresh the page when the location is updated? */


### PR DESCRIPTION
This small change is needed to work with [dash #1531](https://github.com/plotly/dash/pull/1531)

One of the changes in #1531 is to sort the props.  A docstring comment that ends with a `"` in the last prop will cause the component docstring to end with 4 double quotes `""""` which causes an error in the build.  Using a single quote fixes this error.