### PR TITLE
sets autoComplete to off in Dropdown #808

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+
+### Changed
+- [#923](https://github.com/plotly/dash-core-components/pull/923)
+  Set autoComplete to off in `dcc.Dropdown`. This fixes [#808](https://github.com/plotly/dash-core-components/issues/808)
+
 ## [1.15.0] - 2021-01-19
 ### Fixed
 - [#905](https://github.com/plotly/dash-core-components/pull/905) Make sure the `figure` prop of `dcc.Graph` receives updates from user interactions in the graph, by using the same `layout` object as provided in the prop rather than cloning it. Fixes [#879](https://github.com/plotly/dash-core-components/issues/879).

--- a/src/fragments/Dropdown.react.js
+++ b/src/fragments/Dropdown.react.js
@@ -98,7 +98,7 @@ export default class Dropdown extends Component {
                     onInputChange={search_value => setProps({search_value})}
                     backspaceRemoves={clearable}
                     deleteRemoves={clearable}
-                    inputProps={{...inputProps, autoComplete: 'off'}}
+                    inputProps={{autoComplete: 'off'}}
                     {...omit(['setProps', 'value'], this.props)}
                 />
             </div>

--- a/src/fragments/Dropdown.react.js
+++ b/src/fragments/Dropdown.react.js
@@ -54,6 +54,7 @@ export default class Dropdown extends Component {
             style,
             loading_state,
             value,
+            inputProps,
         } = this.props;
         const {filterOptions} = this.state;
         let selectedValue;
@@ -97,6 +98,7 @@ export default class Dropdown extends Component {
                     onInputChange={search_value => setProps({search_value})}
                     backspaceRemoves={clearable}
                     deleteRemoves={clearable}
+                    inputProps={{...inputProps, autoComplete: 'off'}}
                     {...omit(['setProps', 'value'], this.props)}
                 />
             </div>

--- a/src/fragments/Dropdown.react.js
+++ b/src/fragments/Dropdown.react.js
@@ -54,7 +54,6 @@ export default class Dropdown extends Component {
             style,
             loading_state,
             value,
-            inputProps,
         } = this.props;
         const {filterOptions} = this.state;
         let selectedValue;

--- a/tests/unit/Dropdown.test.js
+++ b/tests/unit/Dropdown.test.js
@@ -18,6 +18,7 @@ describe('Props can be set properly', () => {
             {label: 'Disabled', value: 'x', disabled: true},
         ],
         value: 2,
+        autoComplete: 'off',
         optionHeight: 50,
         className: 'dd-class',
         clearable: true,


### PR DESCRIPTION
Currently, the default for autoComplete is "on" in the Dropdown component.   When autoComplete="on", the browser will autocomplete fields based on the history stored in the browser.

![image](https://user-images.githubusercontent.com/72614349/106333764-93b0c380-6246-11eb-9105-d0f01f0aeaeb.png)


This pull request addresses #808, plotly/dash#960 and #787 by setting the autoComplete default to "off"

This issue has also been mentioned numerous times on the community forum:
https://community.plotly.com/t/disable-autocomplete-for-dropdowns-input-box-in-dash/22463
https://community.plotly.com/t/disable-browser-autocomplete-on-multiselect-dropdown/37478
https://community.plotly.com/t/keep-getting-autofill-for-dropdown-not-all-browsers/30359

