### PR TITLE
Add n_clicks to annotationClickData so that callback is fired when clicking on an annotation multiple times

### DIFF
--- a/src/components/Graph.react.js
+++ b/src/components/Graph.react.js
@@ -180,6 +180,8 @@ PlotlyGraph.propTypes = {
 
     /**
      * Data from latest click annotation event. Read-only.
+     * In order for an annotation to be "clickable", set
+     *`captureevents=True` within the annotation object.
      */
     clickAnnotationData: PropTypes.object,
 

--- a/src/fragments/Graph.react.js
+++ b/src/fragments/Graph.react.js
@@ -332,6 +332,14 @@ class PlotlyGraph extends Component {
                 ['event', 'fullAnnotation'],
                 eventData
             );
+            if (this.props.clickAnnotationData) {
+                // Provide n_clicks so that multiple clicks on an annotation are triggered
+                clickAnnotationData.n_clicks = (
+                    parseInt(this.props.clickAnnotationData.n_clicks, 10) + 1
+                );
+            } else {
+                clickAnnotationData.n_clicks = 1;
+            }
             setProps({clickAnnotationData});
         });
         gd.on('plotly_hover', eventData => {


### PR DESCRIPTION
Currently `dash`' verifies that the old props != the new props before firing a callback.

Line: https://github.com/plotly/dash/blame/dev/dash-renderer/src/TreeContainer.js#L126
Commit: https://github.com/plotly/dash/commit/05908b2b9c41e3bb7ec5e5505859c7fb7cb78734

This behavior prevents multiple clicks on the same annotation from firing the callback. 

Dash's comparison may not be the right behavior, but this PR will at least get around the issue.