### PR TITLE
Fix typo in EnhancedTab disabled_className property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - [#930](https://github.com/plotly/dash-core-components/pull/930) Fixed a bug [#867](https://github.com/plotly/dash-core-components/issues/867) with `DatePickerRange` that would sometimes shift the allowed dates by one day.
+- [#934](https://github.com/plotly/dash-core-components/pull/934) Fixed a bug in `EnhancedTab` component that ignored `disabled_className` property
 
 ## [1.15.0] - 2021-01-19
 ### Fixed

--- a/src/components/Tabs.react.js
+++ b/src/components/Tabs.react.js
@@ -218,7 +218,7 @@ export default class Tabs extends Component {
                         value={childProps.value}
                         disabled={childProps.disabled}
                         disabled_style={childProps.disabled_style}
-                        disabled_classname={childProps.disabled_className}
+                        disabled_className={childProps.disabled_className}
                         mobile_breakpoint={this.props.mobile_breakpoint}
                         vertical={this.props.vertical}
                         amountOfTabs={amountOfTabs}

--- a/tests/integration/tab/test_tabs_with_graphs.py
+++ b/tests/integration/tab/test_tabs_with_graphs.py
@@ -24,6 +24,13 @@ def test_graph_does_not_resize_in_tabs(dash_dcc, is_eager):
                 children=[
                     dcc.Tab(label="Tab One", value="tab-1-example", id="tab-1"),
                     dcc.Tab(label="Tab Two", value="tab-2-example", id="tab-2"),
+                    dcc.Tab(
+                        label="Tab Three",
+                        value="tab-3-example",
+                        id="tab-3",
+                        disabled=True,
+                        disabled_className="disabled-tab",
+                    ),
                 ],
             ),
             html.Div(id="tabs-content-example"),
@@ -63,6 +70,9 @@ def test_graph_does_not_resize_in_tabs(dash_dcc, is_eager):
 
     tab_one = dash_dcc.wait_for_element("#tab-1")
     tab_two = dash_dcc.wait_for_element("#tab-2")
+
+    # wait for disabled tab with custom className
+    dash_dcc.wait_for_element("#tab-3.disabled-tab")
 
     WebDriverWait(dash_dcc.driver, 10).until(
         EC.element_to_be_clickable((By.ID, "tab-2"))


### PR DESCRIPTION
I was trying to add custom `className` for the disabled tab through `disabled_className` and faced an issue that the component received `undefined` instead of the provided string. Turned out that the property name was misspelled. So I fixed this by renaming property from `disabled_classname` to `disabled_className`.