### PR TITLE
Added unit for Upload's max_size documentation.

### DIFF
--- a/src/components/Upload.react.js
+++ b/src/components/Upload.react.js
@@ -100,12 +100,12 @@ Upload.propTypes = {
     disable_click: PropTypes.bool,
 
     /**
-     * Maximum file size. If `-1`, then infinite
+     * Maximum file size in bytes. If `-1`, then infinite
      */
     max_size: PropTypes.number,
 
     /**
-     * Minimum file size
+     * Minimum file size in bytes
      */
     min_size: PropTypes.number,
 


### PR DESCRIPTION
We're using ```dcc.Upload``` component and I just had to do a runtime check to verify what unit prefix are we talking about here, so I thought I'll just create a quick PR for that.

Cheers,
Marek