### PR TITLE
Pass a bbox through graph hover data

### DIFF
--- a/src/fragments/Graph.react.js
+++ b/src/fragments/Graph.react.js
@@ -74,6 +74,10 @@ const filterEventData = (gd, eventData, event) => {
             const pointData = filter(function(o) {
                 return !includes(type(o), ['Object', 'Array']);
             }, fullPoint);
+            // permit a bounding box to pass through, if present
+            if (has('bbox', fullPoint)) {
+                pointData.bbox = fullPoint.bbox;
+            }
             if (
                 has('curveNumber', fullPoint) &&
                 has('pointNumber', fullPoint) &&


### PR DESCRIPTION
This PR very minimally passes `bbox`, if present, through Graph component hover data toward custom hover with the ToolTip component in #940.