### PR TITLE
Change Clipboard prop name from `text` to `content`

### DIFF
--- a/src/components/Clipboard.react.js
+++ b/src/components/Clipboard.react.js
@@ -38,9 +38,9 @@ export default class Clipboard extends React.Component {
         return '{' + parts.join(',') + '}';
     }
 
-    async copySuccess(text) {
+    async copySuccess(content) {
         const showCopiedIcon = 1000;
-        await clipboardAPI.writeText(text);
+        await clipboardAPI.writeText(content);
         this.setState({copied: true});
         await wait(showCopiedIcon);
         this.setState({copied: false});
@@ -56,12 +56,12 @@ export default class Clipboard extends React.Component {
                     this.props.target_id
             );
         }
-        let text = target.innerText;
-        if (!text) {
-            text = target.value;
-            text = text === undefined ? null : text;
+        let content = target.innerText;
+        if (!content) {
+            content = target.value;
+            content = content === undefined ? null : content;
         }
-        return text;
+        return content;
     }
 
     async loading() {
@@ -75,16 +75,16 @@ export default class Clipboard extends React.Component {
             n_clicks: this.props.n_clicks + 1,
         });
 
-        let text;
+        let content;
         if (this.props.target_id) {
-            text = this.getTargetText();
+            content = this.getTargetText();
         } else {
             await wait(100); // gives time for callback to start
             await this.loading();
-            text = this.props.text;
+            content = this.props.content;
         }
-        if (text) {
-            this.copySuccess(text);
+        if (content) {
+            this.copySuccess(content);
         }
     }
 
@@ -118,7 +118,7 @@ export default class Clipboard extends React.Component {
 }
 
 Clipboard.defaultProps = {
-    text: null,
+    content: null,
     target_id: null,
     n_clicks: 0,
 };
@@ -139,7 +139,7 @@ Clipboard.propTypes = {
     /**
      * The text to  be copied to the clipboard if the `target_id` is None.
      */
-    text: PropTypes.string,
+    content: PropTypes.string,
 
     /**
      * The number of times copy button was clicked

--- a/tests/integration/clipboard/test_clipboard.py
+++ b/tests/integration/clipboard/test_clipboard.py
@@ -39,7 +39,7 @@ def test_clp002_clipboard_text(dash_dcc_headed):
     copy_text = "Copy this text to the clipboard"
     app = dash.Dash(__name__, prevent_initial_callbacks=True)
     app.layout = html.Div(
-        [dcc.Clipboard(id="copy_icon", text=copy_text), dcc.Textarea(id="paste")]
+        [dcc.Clipboard(id="copy_icon", content=copy_text), dcc.Textarea(id="paste")]
     )
     dash_dcc_headed.start_server(app)
 


### PR DESCRIPTION
This PR changes the prop name from `text` to `content` based on the feedback on the new dash-docs for dcc.Clipboard [here](https://github.com/plotly/dash-docs/pull/1127#discussion_r617720542)